### PR TITLE
feat: add close_session protocol and daemon handler

### DIFF
--- a/cli/src/protocol.rs
+++ b/cli/src/protocol.rs
@@ -40,6 +40,10 @@ pub enum ClientMessage {
         session_id: String,
         new_name: String,
     },
+    /// Close/kill a session
+    CloseSession {
+        session_id: String,
+    },
     /// Register push notification token
     RegisterPushToken {
         token: String,
@@ -212,6 +216,10 @@ pub enum ServerMessage {
     SessionRenamed {
         session_id: String,
         new_name: String,
+    },
+    /// Session closed by client request
+    SessionClosed {
+        session_id: String,
     },
     /// PTY resized confirmation
     PtyResized {


### PR DESCRIPTION
## Summary
- Adds `CloseSession { session_id }` variant to `ClientMessage` in protocol.rs
- Adds `SessionClosed { session_id }` variant to `ServerMessage`
- Implements daemon handler: drops PTY input/resize channels (graceful PTY exit), removes session from HashMap, sends `SessionClosed` confirmation, broadcasts `SessionEnded` to all clients, persists sessions file

## Context
Mobile app needs the ability to close/kill PTY sessions from the long-press menu. This PR adds the server-side protocol and handler; the corresponding mobile UI is in MobileCLI/mobile.

## Test plan
- [ ] Start daemon, create session, send `close_session` message — verify session terminates
- [ ] Verify `SessionClosed` confirmation is received by requesting client
- [ ] Verify `SessionEnded` is broadcast to all connected clients
- [ ] Verify sessions file is updated after close

🤖 Generated with [Claude Code](https://claude.com/claude-code)