### PR TITLE
ci: add Claude Code review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,26 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  claude-review:
+    if: |
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Run Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow for automated Claude Code review on all PRs
- Responds to `@claude` mentions in PR comments for on-demand review
- Uses org-level `ANTHROPIC_API_KEY` secret

## Setup required
- [x] `ANTHROPIC_API_KEY` org secret set
- [ ] Install Claude GitHub App: https://github.com/apps/claude → install on MobileCLI org

🤖 Generated with [Claude Code](https://claude.com/claude-code)