### PR TITLE
Fix TUI resize coordination with epoch-acked PTY resizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ The terminal view is a full xterm.js 5.3 instance running inside a WebView:
 - **Scrollable history** — scroll up through output, auto-scroll follows new content at the bottom
 - **Touch keyboard** with a toolbar providing Esc, arrow keys (for CLI history), paste, and file attachment buttons
 - **Responsive resize** — terminal dimensions adapt to your phone/tablet screen and send the new size to the PTY so output reflows correctly
+- **Desktop-safe by default** — mobile resizing changes the child PTY dimensions without forcing your desktop terminal window to physically resize (`MOBILECLI_DESKTOP_RESIZE_POLICY=mirror` restores legacy mirroring)
 - **Low latency** — WebSocket streaming over LAN is typically sub-10ms
 
 ### File browser and editor *(Pro)*
@@ -414,7 +415,8 @@ MobileCLI/
 
 1. MobileCLI uses xterm.js with full ANSI 256-color support. Ensure your CLI sets `TERM=xterm-256color` (this is the default).
 2. The terminal auto-resizes to fit your phone screen. TUI applications (like `htop` or `vim`) should adapt automatically.
-3. If a session looks garbled after switching tabs, tap the session to re-enter it — the terminal refits on activation.
+3. Desktop terminal geometry is preserved by default. If you explicitly want mirrored desktop window resizing, launch with `MOBILECLI_DESKTOP_RESIZE_POLICY=mirror`.
+4. If a session looks garbled after switching tabs, tap the session to re-enter it — the terminal refits on activation.
 </details>
 
 <details>

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -114,6 +114,9 @@ pub struct PushToken {
 
 /// Default scrollback buffer size (64KB)
 const DEFAULT_SCROLLBACK_MAX_BYTES: usize = 64 * 1024;
+const ALT_ENTER_SEQS: &[&[u8]] = &[b"\x1b[?1049h", b"\x1b[?1047h", b"\x1b[?47h"];
+const ALT_LEAVE_SEQS: &[&[u8]] = &[b"\x1b[?1049l", b"\x1b[?1047l", b"\x1b[?47l"];
+const ALT_TRACK_TAIL_BYTES: usize = 7;
 
 /// Active PTY session
 pub struct PtySession {
@@ -123,7 +126,7 @@ pub struct PtySession {
     pub project_path: String,
     pub started_at: chrono::DateTime<Utc>,
     pub input_tx: mpsc::UnboundedSender<Vec<u8>>,
-    pub resize_tx: mpsc::UnboundedSender<(u16, u16)>,
+    pub resize_tx: mpsc::UnboundedSender<(u16, u16, Option<u64>)>,
     pub waiting_state: Option<WaitingState>,
     pub cli_tracker: CliTracker,
     pub last_wait_hash: Option<u64>,
@@ -134,6 +137,11 @@ pub struct PtySession {
     pub scrollback_max_bytes: usize,
     /// Whether the CLI is currently in alternate screen buffer mode
     pub in_alt_screen: bool,
+    /// Tail bytes from prior chunk used to detect alt-screen escape sequences
+    /// split across PTY read boundaries.
+    pub alt_track_tail: Vec<u8>,
+    /// Latest accepted resize epoch from mobile (for stale resize rejection).
+    pub last_resize_epoch: u64,
 }
 
 /// Daemon shared state
@@ -561,7 +569,7 @@ async fn handle_pty_session(
     tracing::info!("PTY session registered: {} ({})", name, session_id);
 
     let (input_tx, mut input_rx) = mpsc::unbounded_channel::<Vec<u8>>();
-    let (resize_tx, mut resize_rx) = mpsc::unbounded_channel::<(u16, u16)>();
+    let (resize_tx, mut resize_rx) = mpsc::unbounded_channel::<(u16, u16, Option<u64>)>();
 
     // Register session
     let pty_broadcast = {
@@ -585,6 +593,8 @@ async fn handle_pty_session(
                 scrollback: VecDeque::new(),
                 scrollback_max_bytes: DEFAULT_SCROLLBACK_MAX_BYTES,
                 in_alt_screen: false,
+                alt_track_tail: Vec::new(),
+                last_resize_epoch: 0,
             },
         );
         st.pty_broadcast.clone()
@@ -623,19 +633,14 @@ async fn handle_pty_session(
                                                 while session.scrollback.len() > session.scrollback_max_bytes {
                                                     session.scrollback.pop_front();
                                                 }
-                                                // Track alt screen transitions
-                                                const ALT_ENTER: &[u8] = b"\x1b[?1049h";
-                                                const ALT_LEAVE: &[u8] = b"\x1b[?1049l";
-                                                if bytes.len() >= ALT_ENTER.len() {
-                                                    for w in bytes.windows(ALT_ENTER.len()) {
-                                                        if w == ALT_ENTER {
-                                                            session.in_alt_screen = true;
-                                                        }
-                                                        if w == ALT_LEAVE {
-                                                            session.in_alt_screen = false;
-                                                        }
-                                                    }
-                                                }
+                                                // Track alt-screen transitions across chunk
+                                                // boundaries so subscribe_ack reflects the
+                                                // current rendering mode reliably.
+                                                update_alt_screen_state(
+                                                    &mut session.in_alt_screen,
+                                                    &mut session.alt_track_tail,
+                                                    &bytes,
+                                                );
                                             }
                                         }
 
@@ -723,6 +728,11 @@ async fn handle_pty_session(
                                         }
                                     }
                                 }
+                            } else if msg["type"].as_str() == Some("pty_resized") {
+                                let cols = msg["cols"].as_u64().unwrap_or(0).min(u16::MAX as u64) as u16;
+                                let rows = msg["rows"].as_u64().unwrap_or(0).min(u16::MAX as u64) as u16;
+                                let epoch = msg["epoch"].as_u64();
+                                broadcast_pty_resized(&state, &session_id, cols, rows, epoch).await;
                             } else if msg["type"].as_str() == Some("session_ended") {
                                 exit_code = msg["exit_code"].as_i64().unwrap_or(0) as i32;
                                 tracing::info!("PTY session {} ended (exit_code={})", session_id, exit_code);
@@ -774,12 +784,15 @@ async fn handle_pty_session(
             // Resize from mobile
             result = resize_rx.recv() => {
                 match result {
-                    Some((cols, rows)) => {
-                        let msg = serde_json::json!({
+                    Some((cols, rows, epoch)) => {
+                        let mut msg = serde_json::json!({
                             "type": "resize",
                             "cols": cols,
                             "rows": rows,
                         });
+                        if let Some(epoch) = epoch {
+                            msg["epoch"] = serde_json::json!(epoch);
+                        }
                         if tx.send(Message::Text(msg.to_string())).await.is_err() {
                             break;
                         }
@@ -1326,24 +1339,55 @@ async fn process_client_msg(
             session_id,
             cols,
             rows,
+            epoch,
         } => {
-            let st = state.read().await;
+            let mut st = state.write().await;
             let is_restore = cols == 0 && rows == 0;
-            let has_viewers = st
+            let viewer_count = st
                 .session_view_counts
                 .get(&session_id)
                 .copied()
-                .unwrap_or(0)
-                > 0;
-            if !is_restore && !has_viewers {
+                .unwrap_or(0);
+            let sender_is_viewing = st
+                .mobile_views
+                .get(&addr)
+                .map(|views| views.contains(&session_id))
+                .unwrap_or(false);
+
+            if !is_restore && viewer_count == 0 {
                 tracing::debug!(
                     "Ignoring PTY resize for {} (no active mobile viewers)",
                     session_id
                 );
                 return Ok(());
             }
-            if let Some(session) = st.sessions.get(&session_id) {
-                let _ = session.resize_tx.send((cols, rows));
+
+            // A restore request (0x0) must not override active dimensions while
+            // other viewers are still attached to this session.
+            if should_ignore_restore_resize(is_restore, viewer_count, sender_is_viewing) {
+                tracing::debug!(
+                    "Ignoring PTY restore for {} (viewer_count={}, sender_is_viewing={})",
+                    session_id,
+                    viewer_count,
+                    sender_is_viewing
+                );
+                return Ok(());
+            }
+
+            if let Some(session) = st.sessions.get_mut(&session_id) {
+                if is_stale_resize_epoch(session.last_resize_epoch, epoch) {
+                    tracing::debug!(
+                        "Ignoring stale PTY resize for {} (epoch={:?}, last={})",
+                        session_id,
+                        epoch,
+                        session.last_resize_epoch
+                    );
+                    return Ok(());
+                }
+                if let Some(epoch) = epoch {
+                    session.last_resize_epoch = epoch;
+                }
+                let _ = session.resize_tx.send((cols, rows, epoch));
             }
         }
         ClientMessage::Ping => {
@@ -2447,6 +2491,35 @@ async fn broadcast_waiting_cleared(state: &SharedState, session_id: &str) {
     }
 }
 
+/// Broadcast pty_resized to clients actively viewing this session.
+async fn broadcast_pty_resized(
+    state: &SharedState,
+    session_id: &str,
+    cols: u16,
+    rows: u16,
+    epoch: Option<u64>,
+) {
+    let st = state.read().await;
+    let msg = ServerMessage::PtyResized {
+        session_id: session_id.to_string(),
+        cols,
+        rows,
+        epoch,
+    };
+    if let Ok(msg_str) = serde_json::to_string(&msg) {
+        for (addr, client) in &st.mobile_clients {
+            let is_viewing = st
+                .mobile_views
+                .get(addr)
+                .map(|views| views.contains(session_id))
+                .unwrap_or(false);
+            if is_viewing {
+                let _ = client.try_send(Message::Text(msg_str.clone()));
+            }
+        }
+    }
+}
+
 /// Send current waiting states to a newly connected mobile client.
 async fn send_waiting_states(
     state: &SharedState,
@@ -2501,6 +2574,41 @@ fn truncate_to_max_chars(input: &mut String, max_chars: usize) {
     }
     let trimmed: String = input.chars().skip(len - max_chars).collect();
     *input = trimmed;
+}
+
+fn should_ignore_restore_resize(is_restore: bool, viewer_count: usize, sender_is_viewing: bool) -> bool {
+    is_restore && (viewer_count > 1 || (viewer_count == 1 && !sender_is_viewing))
+}
+
+fn is_stale_resize_epoch(last_epoch: u64, incoming_epoch: Option<u64>) -> bool {
+    incoming_epoch.is_some_and(|epoch| epoch <= last_epoch)
+}
+
+/// Update alternate-screen state from a PTY chunk, including sequences split
+/// across chunk boundaries.
+fn update_alt_screen_state(in_alt_screen: &mut bool, tail: &mut Vec<u8>, chunk: &[u8]) {
+    if chunk.is_empty() {
+        return;
+    }
+
+    let mut scan = Vec::with_capacity(tail.len() + chunk.len());
+    scan.extend_from_slice(tail);
+    scan.extend_from_slice(chunk);
+
+    for i in 0..scan.len() {
+        let rem = &scan[i..];
+        if ALT_ENTER_SEQS.iter().any(|seq| rem.starts_with(seq)) {
+            *in_alt_screen = true;
+            continue;
+        }
+        if ALT_LEAVE_SEQS.iter().any(|seq| rem.starts_with(seq)) {
+            *in_alt_screen = false;
+        }
+    }
+
+    let keep = ALT_TRACK_TAIL_BYTES.min(scan.len());
+    tail.clear();
+    tail.extend_from_slice(&scan[scan.len() - keep..]);
 }
 
 fn build_notification_text(
@@ -2608,7 +2716,7 @@ fn is_path_watched(changed_path: &str, watched: &std::collections::HashSet<Strin
 async fn restore_pty_size(state: &SharedState, session_id: &str) {
     let st = state.read().await;
     if let Some(session) = st.sessions.get(session_id) {
-        let _ = session.resize_tx.send((0, 0));
+        let _ = session.resize_tx.send((0, 0, None));
     }
 }
 
@@ -2666,7 +2774,8 @@ async fn send_push_notifications(tokens: &[PushToken], title: &str, body: &str, 
 #[cfg(test)]
 mod tests {
     use super::{
-        build_upload_destination_path, is_windows_reserved_device_name, sanitize_upload_file_name,
+        build_upload_destination_path, is_stale_resize_epoch, is_windows_reserved_device_name,
+        sanitize_upload_file_name, should_ignore_restore_resize, update_alt_screen_state,
         MAX_UPLOAD_FILE_NAME_BYTES,
     };
     use tempfile::TempDir;
@@ -2736,5 +2845,36 @@ mod tests {
         tokio::fs::write(&path, b"x")
             .await
             .expect("unicode path should be writable");
+    }
+
+    #[test]
+    fn update_alt_screen_state_detects_split_enter_and_leave_sequences() {
+        let mut in_alt = false;
+        let mut tail = Vec::new();
+
+        update_alt_screen_state(&mut in_alt, &mut tail, b"\x1b[?10");
+        assert!(!in_alt);
+
+        update_alt_screen_state(&mut in_alt, &mut tail, b"49h");
+        assert!(in_alt);
+
+        update_alt_screen_state(&mut in_alt, &mut tail, b"\x1b[?1049l");
+        assert!(!in_alt);
+    }
+
+    #[test]
+    fn restore_resize_rules_protect_active_viewers() {
+        assert!(should_ignore_restore_resize(true, 2, true));
+        assert!(should_ignore_restore_resize(true, 1, false));
+        assert!(!should_ignore_restore_resize(true, 1, true));
+        assert!(!should_ignore_restore_resize(false, 2, true));
+    }
+
+    #[test]
+    fn stale_epoch_detection_rejects_older_or_equal_epochs() {
+        assert!(!is_stale_resize_epoch(0, None));
+        assert!(!is_stale_resize_epoch(5, Some(6)));
+        assert!(is_stale_resize_epoch(5, Some(5)));
+        assert!(is_stale_resize_epoch(5, Some(4)));
     }
 }

--- a/cli/src/protocol.rs
+++ b/cli/src/protocol.rs
@@ -30,6 +30,8 @@ pub enum ClientMessage {
         session_id: String,
         cols: u16,
         rows: u16,
+        #[serde(default)]
+        epoch: Option<u64>,
     },
     /// Heartbeat ping
     Ping,
@@ -231,6 +233,8 @@ pub enum ServerMessage {
         session_id: String,
         cols: u16,
         rows: u16,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        epoch: Option<u64>,
     },
     /// Heartbeat pong
     Pong,

--- a/cli/src/pty_wrapper.rs
+++ b/cli/src/pty_wrapper.rs
@@ -41,6 +41,33 @@ pub struct WrapConfig {
     pub working_dir: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DesktopResizePolicy {
+    /// Keep the host terminal window unchanged; only resize the child PTY.
+    Preserve,
+    /// Mirror mobile dimensions into the host terminal window.
+    Mirror,
+}
+
+impl DesktopResizePolicy {
+    fn from_env() -> Self {
+        let raw = std::env::var("MOBILECLI_DESKTOP_RESIZE_POLICY")
+            .unwrap_or_else(|_| "preserve".to_string())
+            .to_lowercase();
+        match raw.as_str() {
+            "mirror" | "strict" | "legacy" => Self::Mirror,
+            "preserve" | "off" | "none" | "" => Self::Preserve,
+            other => {
+                tracing::warn!(
+                    "Unknown MOBILECLI_DESKTOP_RESIZE_POLICY='{}'. Defaulting to 'preserve'.",
+                    other
+                );
+                Self::Preserve
+            }
+        }
+    }
+}
+
 /// Resolve a command to its full path
 fn resolve_command(cmd: &str) -> Option<String> {
     // First check if it's already an absolute path
@@ -311,6 +338,7 @@ pub async fn run_wrapped(config: WrapConfig) -> Result<i32, WrapError> {
 
     // Main event loop
     let mut stdout = std::io::stdout();
+    let desktop_resize_policy = DesktopResizePolicy::from_env();
     let mut saved_local_size: Option<(u16, u16)> = None;
     let mut exit_code: i32 = 0;
 
@@ -318,9 +346,7 @@ pub async fn run_wrapped(config: WrapConfig) -> Result<i32, WrapError> {
         tokio::select! {
             // PTY output
             Some(data) = output_rx.recv() => {
-                // Always write to local terminal. When mobile is connected the
-                // desktop terminal is physically resized to match mobile dims
-                // via request_terminal_resize(), so both views stay in sync.
+                // Always write to local terminal output.
                 let _ = stdout.write_all(&data);
                 let _ = stdout.flush();
 
@@ -365,34 +391,71 @@ pub async fn run_wrapped(config: WrapConfig) -> Result<i32, WrapError> {
                                         msg["cols"].as_u64(),
                                         msg["rows"].as_u64(),
                                     ) {
+                                        let epoch = msg["epoch"].as_u64();
                                         if cols == 0 || rows == 0 {
-                                            // Mobile disconnected: restore desktop terminal size.
-                                            // PTY output to stdout resumes automatically
-                                            // (saved_local_size becomes None via .take()).
-                                            let (c, r) = if let Some((lc, lr)) = saved_local_size.take() {
-                                                request_terminal_resize(lc, lr);
-                                                (lc, lr)
-                                            } else {
-                                                get_terminal_size()
+                                            // Mobile detached. Restore PTY dimensions to the
+                                            // host terminal's current size. In mirror mode,
+                                            // also restore the host window to the original size.
+                                            let (c, r) = match desktop_resize_policy {
+                                                DesktopResizePolicy::Mirror => {
+                                                    if let Some((lc, lr)) = saved_local_size.take() {
+                                                        request_terminal_resize(lc, lr);
+                                                        (lc, lr)
+                                                    } else {
+                                                        get_terminal_size()
+                                                    }
+                                                }
+                                                DesktopResizePolicy::Preserve => {
+                                                    saved_local_size = None;
+                                                    get_terminal_size()
+                                                }
                                             };
-                                            let _ = master.resize(PtySize {
+
+                                            let resized = master.resize(PtySize {
                                                 rows: r, cols: c,
                                                 pixel_width: 0, pixel_height: 0,
                                             });
+                                            if resized.is_ok() {
+                                                let mut resized_msg = serde_json::json!({
+                                                    "type": "pty_resized",
+                                                    "cols": c,
+                                                    "rows": r,
+                                                });
+                                                if let Some(epoch) = epoch {
+                                                    resized_msg["epoch"] = serde_json::json!(epoch);
+                                                }
+                                                let _ = ws_tx.send(Message::Text(resized_msg.to_string())).await;
+                                            }
                                         } else {
-                                            // Mobile active: resize both PTY and desktop
-                                            // terminal to mobile dimensions so both views
-                                            // show identical output simultaneously.
-                                            if saved_local_size.is_none() {
+                                            // Mobile active: always resize child PTY to mobile
+                                            // dimensions. Host terminal mirroring is opt-in via
+                                            // MOBILECLI_DESKTOP_RESIZE_POLICY=mirror.
+                                            if desktop_resize_policy == DesktopResizePolicy::Mirror
+                                                && saved_local_size.is_none()
+                                            {
                                                 saved_local_size = get_terminal_size_opt();
                                             }
                                             let c = cols.min(u16::MAX as u64) as u16;
                                             let r = rows.min(u16::MAX as u64) as u16;
-                                            request_terminal_resize(c, r);
-                                            let _ = master.resize(PtySize {
+                                            if desktop_resize_policy == DesktopResizePolicy::Mirror {
+                                                request_terminal_resize(c, r);
+                                            }
+
+                                            let resized = master.resize(PtySize {
                                                 rows: r, cols: c,
                                                 pixel_width: 0, pixel_height: 0,
                                             });
+                                            if resized.is_ok() {
+                                                let mut resized_msg = serde_json::json!({
+                                                    "type": "pty_resized",
+                                                    "cols": c,
+                                                    "rows": r,
+                                                });
+                                                if let Some(epoch) = epoch {
+                                                    resized_msg["epoch"] = serde_json::json!(epoch);
+                                                }
+                                                let _ = ws_tx.send(Message::Text(resized_msg.to_string())).await;
+                                            }
                                         }
                                     }
                                 }

--- a/docs/TUI_RENDERING_STABILIZATION_PLAN.md
+++ b/docs/TUI_RENDERING_STABILIZATION_PLAN.md
@@ -1,0 +1,232 @@
+# TUI Rendering Stabilization Plan (Cross-Device, Future-Proof)
+
+Date: 2026-02-23
+Scope: `cli/` daemon + PTY wrapper and `mobile/` xterm WebView client
+
+## 1. Goal
+
+Make terminal rendering reliable for:
+- Any CLI/TUI today (Codex, Claude, Gemini, OpenCode, shells, ncurses apps)
+- Any device class (desktop, phone, tablet)
+- Any viewport transitions (keyboard show/hide, rotation, split-screen, reconnect)
+- Multi-view sessions (desktop + one or more mobile viewers)
+
+Success means:
+- No duplicate ghost rendering caused by host-window resize/reflow side effects
+- No session cut-offs from resize storms, reconnects, or dropped output chunks
+- Deterministic resize semantics independent of a specific CLI implementation
+
+## 2. Ground Truth From Audit
+
+### 2.1 Core behavioral decision
+
+Default behavior should preserve host terminal geometry and resize only the child PTY.
+
+Rationale:
+- Xterm control sequence docs define `CSI 8 ; h ; w t` as terminal window manipulation. Triggering host window resizing invites emulator-specific reflow behavior that TUIs do not expect.
+- Linux `TIOCSWINSZ` semantics send `SIGWINCH` to the foreground process group; that signal is what TUIs need for redraw. The child PTY resize is sufficient for functional correctness.
+
+References:
+- xterm control sequences (window manipulation): https://www.invisible-island.net/xterm/ctlseqs/ctlseqs.html
+- `TIOCSWINSZ` + `SIGWINCH`: https://man7.org/linux/man-pages/man2/TIOCSWINSZ.2const.html
+
+### 2.2 xterm.js constraints that affect architecture
+
+- `term.write(...)` is asynchronous and buffered. Very fast producers can overflow buffers and drop data unless flow control is explicit.
+- Fit/resizing and high-frequency writes need backpressure-aware handling.
+
+References:
+- xterm flow control guide: https://xtermjs.org/docs/guides/flowcontrol/
+- xterm API `write`, `onResize`: https://xtermjs.org/docs/api/terminal/classes/terminal/
+
+### 2.3 Keyboard/viewport reality
+
+Mobile keyboard and viewport events are noisy and bursty. The visual viewport can resize independently of layout viewport; resize handling must be idempotent and debounced.
+
+Reference:
+- VisualViewport resize: https://developer.mozilla.org/en-US/docs/Web/API/VisualViewport/resize_event
+
+## 3. Implemented Fixes (Current Branch)
+
+Branch:
+- Top-level repo: `fix/tui-resize-coordination`
+- Nested mobile repo (`mobile/`): `fix/tui-resize-coordination`
+
+### 3.1 PTY wrapper and daemon
+
+- Added desktop resize policy in PTY wrapper:
+  - `MOBILECLI_DESKTOP_RESIZE_POLICY=preserve` (default)
+  - `mirror` (legacy behavior)
+- Removed screen-clearing resize path from wrapper logic.
+- Wrapper now emits `pty_resized` confirmations after applied PTY resize.
+- Daemon now rebroadcasts `pty_resized` to active viewers only.
+
+### 3.2 Mobile terminal path
+
+- `pty_resized` now clears suppression in `useSync`.
+- `pty_resize` messages are queueable during transient WS disconnects.
+- Removed overlapping AppState resize path in `TerminalView`.
+- Reduced duplicate resize notifications in `assets/xterm.html`.
+- Switched to streaming UTF-8 decode to avoid multibyte split corruption.
+- Session lifecycle consolidated to attach/detach callbacks.
+
+### 3.3 Additional hardening in this pass
+
+- Daemon alt-screen tracking now handles split escape sequences across PTY chunk boundaries.
+- Daemon restore (`cols=0, rows=0`) is ignored when multiple viewers still watch a session.
+- Resize epochs now propagate mobile -> daemon -> wrapper -> daemon -> mobile, and stale epoch requests are rejected server-side.
+- Mobile reconnect path now re-sends last known dimensions to break suppression deadlocks.
+- Session detach no longer sends eager `resize(0,0)`; daemon restores when last viewer unsubscribes.
+
+## 4. Remaining Risk Areas
+
+1. Output backpressure in `mobile/components/XTermView.tsx`
+- Current queue still has bounded-drop behavior under sustained high throughput.
+- Risk: partial history loss under very heavy output bursts.
+
+2. Resize event storms and stale dims ordering
+- Multiple async layers (RN layout, WebView, WS queue, daemon channel, PTY) can still reorder effectively under reconnect churn.
+
+3. Alt-screen model is stronger but still heuristic
+- We currently infer mode from known DECSET/DECRST sequences; unusual apps may use non-standard flows.
+
+4. Cross-emulator behavior variance
+- Konsole, GNOME Terminal, iTerm2, WezTerm, Kitty differ in host-resize and repaint behavior.
+
+## 5. Stabilization Roadmap
+
+## Phase A: Deterministic Resize State Machine (High Priority)
+
+1. Introduce monotonic resize epochs per session.
+- Mobile tags each outbound `pty_resize` with `epoch`.
+- Wrapper/daemon echo `epoch` in `pty_resized`.
+- Mobile clears suppression only for matching/latest epoch.
+
+2. Ensure single source of truth for active dimensions.
+- Store `last_applied_cols/rows` in daemon session state.
+- Reject no-op or stale resizes server-side.
+
+3. Collapse redundant restore paths.
+- Keep restore exclusively server-owned when viewer count reaches 0.
+- Treat client-side `resize(0,0)` as advisory only (or remove protocol path entirely).
+
+Deliverable:
+- Race-free handshake: `subscribe_ack -> resize(epoch) -> pty_resized(epoch)`.
+
+## Phase B: Lossless Output Delivery Under Load (High Priority)
+
+1. Replace drop-oldest queue strategy with watermark backpressure.
+- Follow xterm guidance: pause/resume producer with ACK-based watermark.
+- Since transport is WebSocket, apply logical ACK protocol between WebView and RN, and RN to daemon.
+
+2. Add bounded memory policy without silent loss.
+- If hard limit must trigger, inject explicit marker frame (`[output truncated due to overload]`) and metric event.
+- Never silently discard bytes.
+
+3. Add throughput telemetry.
+- Queue depth, max lag ms, dropped bytes (must trend to zero), flush batch size.
+
+Deliverable:
+- No silent truncation during stress tests.
+
+## Phase C: Mobile Viewport Robustness (Medium Priority)
+
+1. Introduce viewport stabilization gate.
+- Delay outward resize until dimensions stable for N ms and changed by threshold.
+- Use VisualViewport where available, fallback to layout events.
+
+2. Keyboard transition guardrails.
+- Coalesce keyboard show/hide oscillations into one applied resize per transition.
+
+3. Orientation and split-screen profile tests.
+- Portrait/landscape flips while alt-screen is active.
+
+Deliverable:
+- Predictable resize rate and no resize thrash from keyboard animations.
+
+## Phase D: Interop and Emulator Matrix (Medium Priority)
+
+1. Validate `preserve` default across host emulators:
+- Konsole, GNOME Terminal, iTerm2, WezTerm, Kitty.
+
+2. Validate CLI matrix:
+- main-screen output (shell, Claude-like)
+- alt-screen TUI (Codex-like, ncurses, htop, vim, less)
+
+3. Keep `mirror` as explicit legacy mode only.
+- Document as compatibility fallback, not default.
+
+Deliverable:
+- Compatibility matrix checked and documented before merge.
+
+## 6. Test Plan (Required Before Final Commit)
+
+## 6.1 Automated checks
+
+- `cargo check --manifest-path cli/Cargo.toml`
+- `npx tsc --noEmit` in `mobile/`
+- Add targeted unit tests:
+  - alt-screen detector with chunk-split sequences (`1049h`, `1047h`, `47h` and leave variants)
+  - resize gating with multi-viewer restore rejection
+
+## 6.2 Scripted integration tests
+
+- Simulate sequence:
+  - subscribe
+  - alt-screen enter
+  - rapid resize burst
+  - unsubscribe/reconnect
+- Assert:
+  - no stale suppression
+  - latest epoch wins
+  - no unexpected restore when viewer count > 1
+
+## 6.3 Manual device matrix
+
+- iOS (latest + one prior major), Android (two API levels)
+- Small phone, large phone, tablet
+- Desktop Linux/macOS host emulators
+
+Scenarios:
+- Keyboard up/down spam
+- Rotate during active prompt
+- Background/foreground app repeatedly
+- Reconnect under packet loss or daemon restart
+- Large output flood (long logs, rapid redraw TUI)
+
+Acceptance criteria:
+- No duplicate UI artifacts
+- No blank top gaps after scrollback
+- No history truncation except explicit overload marker
+- Desktop view remains stable in preserve mode
+
+## 7. Observability Additions
+
+Add structured logs and counters (session-scoped):
+- resize requested/applied (cols, rows, epoch)
+- suppression set/cleared reason
+- queued messages count and flush latency
+- output queue high-water and drops
+- viewer_count transitions and restore decisions
+
+Use these to verify behavior before and after rollout.
+
+## 8. Rollout Strategy
+
+1. Keep feature flags/env controls:
+- desktop resize policy (`preserve` default)
+- optional experimental backpressure protocol
+
+2. Release in two steps:
+- Step 1: deterministic resize + multi-view safety + observability
+- Step 2: backpressure/lossless pipeline
+
+3. If regressions appear:
+- fallback to prior stable path via flag without code rollback.
+
+## 9. Proposed Immediate Next Implementation Tasks
+
+1. Extend daemon tests to cover stale-epoch rejection in multi-resize reconnect scenarios.
+2. Implement non-lossy high/low watermark output flow in WebView/RN path.
+3. Add compatibility matrix checklist and record results in docs.
+4. Add resize/apply telemetry dashboards for queue depth and ack lag.


### PR DESCRIPTION
## Summary
- default desktop-safe resize policy: keep host terminal geometry unchanged and resize only the child PTY (legacy mirror remains opt-in)
- add end-to-end epoch support for pty_resize / pty_resized and reject stale resize epochs server-side
- harden multi-view behavior by ignoring restore resizes while other viewers remain attached
- improve alt-screen tracking to detect split escape sequences across PTY chunk boundaries
- add daemon tests for alt-screen split sequence handling, restore gating, and stale epoch rejection
- add a detailed stabilization roadmap doc and README notes for resize behavior

## Key Files
- cli/src/protocol.rs
- cli/src/daemon.rs
- cli/src/pty_wrapper.rs
- docs/TUI_RENDERING_STABILIZATION_PLAN.md
- README.md

## Validation
- cargo check --manifest-path cli/Cargo.toml
- cargo test --manifest-path cli/Cargo.toml daemon::tests -- --nocapture
