### PR TITLE
feat: Direct PTY Architecture - Remove tmux

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -11,9 +11,10 @@ on:
 jobs:
   claude-review:
     if: |
-      (github.event_name == 'pull_request') ||
+      secrets.ANTHROPIC_API_KEY != '' &&
+      ((github.event_name == 'pull_request') ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -25,3 +26,4 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -19,6 +19,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
     steps:
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@v1

--- a/cli/src/autostart.rs
+++ b/cli/src/autostart.rs
@@ -31,19 +31,19 @@ fn install() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(target_os = "linux")]
     {
         install_systemd_user()?;
-        return Ok(());
+        Ok(())
     }
 
     #[cfg(target_os = "macos")]
     {
         install_launchd_agent()?;
-        return Ok(());
+        Ok(())
     }
 
     #[cfg(target_os = "windows")]
     {
         install_windows_task()?;
-        return Ok(());
+        Ok(())
     }
 
     #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
@@ -57,19 +57,19 @@ fn uninstall() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(target_os = "linux")]
     {
         uninstall_systemd_user()?;
-        return Ok(());
+        Ok(())
     }
 
     #[cfg(target_os = "macos")]
     {
         uninstall_launchd_agent()?;
-        return Ok(());
+        Ok(())
     }
 
     #[cfg(target_os = "windows")]
     {
         uninstall_windows_task()?;
-        return Ok(());
+        Ok(())
     }
 
     #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -1426,7 +1426,7 @@ async fn process_client_msg(
             let (
                 scrollback_bytes,
                 render_as_tui,
-                in_alt_screen,
+                mobile_in_alt_screen,
                 queue_deferred_replay,
                 scrollback_len,
                 runtime,
@@ -1434,6 +1434,11 @@ async fn process_client_msg(
                 tmux_fallback_bytes,
             ) = if let Some(session) = st.sessions.get(&session_id) {
                 let render_as_tui = should_treat_as_tui_for_mobile(
+                    &session.runtime,
+                    session.in_alt_screen,
+                    session.frame_render_mode,
+                );
+                let mobile_in_alt_screen = should_mobile_enter_alt_screen(
                     &session.runtime,
                     session.in_alt_screen,
                     session.frame_render_mode,
@@ -1486,7 +1491,7 @@ async fn process_client_msg(
                 (
                     sb,
                     render_as_tui,
-                    session.in_alt_screen,
+                    mobile_in_alt_screen,
                     // tmux sessions use capture-pane snapshots; raw deferred replay
                     // of daemon scrollback corrupts TUIs on reconnect.
                     runtime != "tmux" && render_as_tui && has_scrollback,
@@ -1519,7 +1524,7 @@ async fn process_client_msg(
                 addr = %addr,
                 runtime = %runtime,
                 render_as_tui,
-                in_alt_screen,
+                mobile_in_alt_screen,
                 queue_deferred_replay,
                 scrollback_len,
                 text_replay_bytes = scrollback_bytes.as_ref().map(|b| b.len()).unwrap_or(0),
@@ -1531,12 +1536,18 @@ async fn process_client_msg(
             //
             // On every (re-)subscribe we first clear the client terminal so
             // that replay data doesn't append to stale content from a prior
-            // subscribe.  TUI sessions enter alternate-screen (no scrollback,
-            // overwritten by the SIGWINCH-triggered redraw).  Text sessions
+            // subscribe. Sessions in mobile alternate-screen use 1049h clear.
+            // Main-buffer sessions erase display+scrollback so the next render
+            // starts from a deterministic baseline.
+            //
+            // tmux frame sessions intentionally stay in the main buffer to
+            // preserve mobile-side scrollback and manual panning.
+            //
+            // Text sessions
             // erase the display *and* the scrollback buffer (\x1b[3J) so that
             // the SessionHistory that follows is the only content.
             {
-                let clear: &[u8] = if render_as_tui {
+                let clear: &[u8] = if mobile_in_alt_screen {
                     // \x1b[?1049h  enter alternate screen
                     // \x1b[2J      erase display
                     // \x1b[H       cursor home
@@ -1615,7 +1626,7 @@ async fn process_client_msg(
             // stale bytes and enter alt-screen mode before resizing.
             let ack = ServerMessage::SubscribeAck {
                 session_id,
-                in_alt_screen: render_as_tui,
+                in_alt_screen: mobile_in_alt_screen,
                 runtime: Some(runtime),
             };
             if let Ok(text) = serde_json::to_string(&ack) {
@@ -3396,6 +3407,24 @@ fn should_treat_as_tui_for_mobile(
     in_alt_screen || frame_render_mode
 }
 
+fn should_mobile_enter_alt_screen(
+    runtime: &str,
+    in_alt_screen: bool,
+    frame_render_mode: bool,
+) -> bool {
+    // Preserve real alternate-screen behavior when the app explicitly requests it.
+    if in_alt_screen {
+        return true;
+    }
+    // tmux runtime intentionally disables alternate-screen at the host level.
+    // For frame-rendering apps under tmux we keep mobile in the main buffer so
+    // users can retain scrollback and pan through prior output.
+    if runtime == "tmux" {
+        return false;
+    }
+    frame_render_mode
+}
+
 fn is_stale_resize_epoch(last_epoch: u64, incoming_epoch: Option<u64>) -> bool {
     incoming_epoch.is_some_and(|epoch| epoch <= last_epoch)
 }
@@ -3432,7 +3461,10 @@ fn cli_defaults_to_frame_mode(cli: CliType) -> bool {
     // mobile subscribe (before the output heuristic has seen enough frames)
     // skips the desktop-width capture-pane and enters alt-screen immediately.
     // The heuristic still runs and will detect any other frame-rendering app.
-    matches!(cli, CliType::Codex | CliType::OpenCode | CliType::Claude)
+    matches!(
+        cli,
+        CliType::Codex | CliType::OpenCode | CliType::Claude | CliType::Gemini
+    )
 }
 
 fn should_enable_frame_mode(cursor_ops: u32, erase_ops: u32) -> bool {
@@ -3706,10 +3738,11 @@ mod tests {
         is_stale_resize_epoch, is_windows_reserved_device_name, resolve_resize_reason,
         sanitize_upload_file_name, scan_frame_sequences, should_enable_frame_mode,
         should_force_noop_resize, should_ignore_resize_without_viewers,
-        should_ignore_restore_resize, should_treat_as_tui_for_mobile,
-        strip_terminal_report_sequences, strip_terminal_report_sequences_stateful,
-        update_alt_screen_state, update_frame_render_state, DaemonState, PtyResizeReason,
-        PtySession, DEFAULT_SCROLLBACK_MAX_BYTES, MAX_UPLOAD_FILE_NAME_BYTES,
+        should_ignore_restore_resize, should_mobile_enter_alt_screen,
+        should_treat_as_tui_for_mobile, strip_terminal_report_sequences,
+        strip_terminal_report_sequences_stateful, update_alt_screen_state,
+        update_frame_render_state, DaemonState, PtyResizeReason, PtySession,
+        DEFAULT_SCROLLBACK_MAX_BYTES, MAX_UPLOAD_FILE_NAME_BYTES,
     };
     use crate::detection::{CliTracker, CliType};
     use base64::Engine as _;
@@ -4007,14 +4040,22 @@ mod tests {
     #[test]
     fn tui_gating_uses_frame_render_for_all_runtimes() {
         // alternate-screen is disabled in tmux so in_alt_screen is always
-        // false there.  frame_render_mode must trigger TUI treatment for
-        // tmux sessions too, otherwise mobile never enters alt-screen and
-        // every TUI frame pollutes main-buffer scrollback.
+        // false there. frame_render_mode must still gate replay behavior for
+        // tmux sessions to avoid dumping raw frame redraw traffic as history.
         assert!(should_treat_as_tui_for_mobile("tmux", false, true));
         assert!(!should_treat_as_tui_for_mobile("tmux", false, false));
         assert!(should_treat_as_tui_for_mobile("tmux", true, false));
         assert!(should_treat_as_tui_for_mobile("pty", false, true));
         assert!(!should_treat_as_tui_for_mobile("pty", false, false));
+    }
+
+    #[test]
+    fn mobile_alt_screen_policy_preserves_tmux_scrollback() {
+        assert!(!should_mobile_enter_alt_screen("tmux", false, true));
+        assert!(!should_mobile_enter_alt_screen("tmux", false, false));
+        assert!(should_mobile_enter_alt_screen("tmux", true, false));
+        assert!(should_mobile_enter_alt_screen("pty", false, true));
+        assert!(!should_mobile_enter_alt_screen("pty", false, false));
     }
 
     #[test]
@@ -4054,6 +4095,7 @@ mod tests {
         assert!(super::cli_defaults_to_frame_mode(CliType::Codex));
         assert!(super::cli_defaults_to_frame_mode(CliType::OpenCode));
         assert!(super::cli_defaults_to_frame_mode(CliType::Claude));
+        assert!(super::cli_defaults_to_frame_mode(CliType::Gemini));
         assert!(!super::cli_defaults_to_frame_mode(CliType::Terminal));
     }
 

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -120,6 +120,18 @@ pub struct PushToken {
 /// "lost" earlier chat. Retaining a larger buffer keeps substantially more
 /// recoverable history while still bounding memory.
 const DEFAULT_SCROLLBACK_MAX_BYTES: usize = 8 * 1024 * 1024;
+
+/// Maximum tmux scrollback lines fetched via capture-pane on the subscribe path.
+///
+/// Mobile xterm.js holds 20 000 lines. Desktop sessions are typically 160–240 cols
+/// while mobile is 80–100 cols, giving a worst-case wrap ratio of ~3×. So 10 000
+/// tmux lines → up to ~30 000 visual lines, which keeps the buffer well-fed without
+/// sending megabytes of scrollback that will immediately be discarded by xterm.js.
+///
+/// For on-demand `GetSessionHistory` requests the full 200 000-line depth is used.
+const SUBSCRIBE_SCROLLBACK_LINES: usize = 10_000;
+const HISTORY_SCROLLBACK_LINES: usize = 200_000;
+
 const ALT_ENTER_SEQS: &[&[u8]] = &[b"\x1b[?1049h", b"\x1b[?1047h", b"\x1b[?47h"];
 const ALT_LEAVE_SEQS: &[&[u8]] = &[b"\x1b[?1049l", b"\x1b[?1047l", b"\x1b[?47l"];
 const ALT_TRACK_TAIL_BYTES: usize = 7;
@@ -1171,8 +1183,16 @@ async fn spawn_session_from_mobile(
     } else {
         "/bin/sh".to_string()
     };
+    // Default to home directory when no working_dir is specified.
+    // Without this, the spawned terminal inherits the daemon's CWD,
+    // which is wherever the daemon was launched from (often the project dir).
+    let home_dir_buf = dirs_next::home_dir();
+    let effective_working_dir: Option<&str> = working_dir.or_else(|| {
+        home_dir_buf.as_ref().and_then(|p| p.to_str())
+    });
+
     let wrap_cmd =
-        build_wrap_shell_command(&mobilecli_bin, session_name, command, args, working_dir);
+        build_wrap_shell_command(&mobilecli_bin, session_name, command, args, effective_working_dir);
     let shell_args = shell_args_for_command(&shell, &wrap_cmd);
 
     let mut cmd = if let Some(ref terminal) = terminal {
@@ -1256,8 +1276,8 @@ async fn spawn_session_from_mobile(
         }
     };
 
-    // Set working directory if specified
-    if let Some(dir) = working_dir {
+    // Set working directory (defaults to home dir when not specified by caller)
+    if let Some(dir) = effective_working_dir {
         cmd.current_dir(dir);
     }
 
@@ -1402,11 +1422,11 @@ async fn process_client_msg(
                 scrollback_bytes,
                 render_as_tui,
                 in_alt_screen,
-                frame_render_mode,
                 queue_deferred_replay,
                 scrollback_len,
                 runtime,
                 tmux_snapshot_req,
+                tmux_fallback_bytes,
             ) = if let Some(session) = st.sessions.get(&session_id) {
                 let render_as_tui = should_treat_as_tui_for_mobile(
                     &session.runtime,
@@ -1415,15 +1435,33 @@ async fn process_client_msg(
                 );
                 let has_scrollback = !session.scrollback.is_empty();
                 let runtime = session.runtime.clone();
-                let tmux_snapshot_req = if runtime == "tmux" && !render_as_tui {
-                    match (&session.tmux_socket, &session.tmux_session) {
-                        (Some(socket), Some(name)) => Some((
-                            socket.clone(),
-                            name.clone(),
-                            session.scrollback_max_bytes,
-                            true,
-                        )),
-                        _ => None,
+                // alternate-screen is disabled in tmux so the host terminal (e.g.
+                // Konsole) never enters its own alt-screen and loses scrollback.
+                // This means in_alt_screen is always false for tmux sessions; we
+                // instead use frame_render_mode to distinguish between text CLIs
+                // (which get real scrollback history) and frame-rendering TUIs
+                // (which flood scrollback with cursor-home+clear frames and should
+                // instead get a visible-pane snapshot of their current screen state).
+                // frame_render_mode is detected from observable output patterns —
+                // any app that emits heavy cursor-repositioning qualifies, regardless
+                // of what the app is called.
+                let frame_render = session.frame_render_mode;
+                let tmux_snapshot_req = if runtime == "tmux" {
+                    if frame_render {
+                        // Frame-rendering TUIs redraw their entire screen on SIGWINCH.
+                        // Skip capture — it would be at desktop dimensions and get
+                        // immediately overwritten by the resize-triggered redraw.
+                        None
+                    } else {
+                        match (&session.tmux_socket, &session.tmux_session) {
+                            (Some(socket), Some(name)) => Some((
+                                socket.clone(),
+                                name.clone(),
+                                session.scrollback_max_bytes,
+                                true,
+                            )),
+                            _ => None,
+                        }
                     }
                 } else {
                     None
@@ -1433,20 +1471,27 @@ async fn process_client_msg(
                 } else {
                     None
                 };
+                // Daemon in-memory scrollback fallback for tmux text sessions when
+                // capture-pane is unavailable (socket startup race, etc.).
+                let tmux_fallback = if runtime == "tmux" && !frame_render && has_scrollback {
+                    Some(session.scrollback.iter().copied().collect::<Vec<u8>>())
+                } else {
+                    None
+                };
                 (
                     sb,
                     render_as_tui,
                     session.in_alt_screen,
-                    session.frame_render_mode,
                     // tmux sessions use capture-pane snapshots; raw deferred replay
-                    // of daemon scrollback corrupts frame TUIs on reconnect.
+                    // of daemon scrollback corrupts TUIs on reconnect.
                     runtime != "tmux" && render_as_tui && has_scrollback,
                     session.scrollback.len(),
                     runtime,
                     tmux_snapshot_req,
+                    tmux_fallback,
                 )
             } else {
-                (None, false, false, false, false, 0, "pty".to_string(), None)
+                (None, false, false, false, 0, "pty".to_string(), None, None)
             };
 
             if queue_deferred_replay {
@@ -1470,7 +1515,6 @@ async fn process_client_msg(
                 runtime = %runtime,
                 render_as_tui,
                 in_alt_screen,
-                frame_render_mode,
                 queue_deferred_replay,
                 scrollback_len,
                 text_replay_bytes = scrollback_bytes.as_ref().map(|b| b.len()).unwrap_or(0),
@@ -1492,8 +1536,16 @@ async fn process_client_msg(
             }
 
             if let Some((socket, name, max_bytes, include_scrollback)) = tmux_snapshot_req {
+                // Text sessions use capped subscribe depth; visible-pane captures
+                // (TUI sessions in alt-screen) pass max_lines=0 which is ignored.
+                let max_lines = if include_scrollback {
+                    SUBSCRIBE_SCROLLBACK_LINES
+                } else {
+                    0
+                };
                 if let Some(snapshot) =
-                    capture_tmux_history_with_retry(socket, name, include_scrollback).await
+                    capture_tmux_history_with_retry(socket, name, include_scrollback, max_lines)
+                        .await
                 {
                     let total_bytes = snapshot.len();
                     let skip = total_bytes.saturating_sub(max_bytes);
@@ -1501,6 +1553,24 @@ async fn process_client_msg(
                     let msg = ServerMessage::SessionHistory {
                         session_id: session_id.clone(),
                         data: BASE64.encode(bytes),
+                        total_bytes,
+                    };
+                    if let Ok(text) = serde_json::to_string(&msg) {
+                        let _ = tx.send(Message::Text(text)).await;
+                    }
+                } else if let Some(fallback) = tmux_fallback_bytes {
+                    // capture-pane unavailable (socket not yet ready, tmux startup
+                    // race, etc.) – fall back to the daemon's in-memory PTY stream
+                    // so mobile at least sees recent output rather than a blank terminal.
+                    tracing::debug!(
+                        session_id = %session_id,
+                        fallback_bytes = fallback.len(),
+                        "capture-pane failed on subscribe; using daemon scrollback fallback"
+                    );
+                    let total_bytes = fallback.len();
+                    let msg = ServerMessage::SessionHistory {
+                        session_id: session_id.clone(),
+                        data: BASE64.encode(&fallback),
                         total_bytes,
                     };
                     if let Ok(text) = serde_json::to_string(&msg) {
@@ -1925,8 +1995,16 @@ async fn process_client_msg(
 
             let (data, total_bytes) =
                 if let Some((socket, name, max, include_scrollback)) = tmux_capture_req {
+                    // On-demand history requests use the full depth so users can
+                    // retrieve the maximum available scrollback from tmux.
+                    let max_lines = if include_scrollback {
+                        HISTORY_SCROLLBACK_LINES
+                    } else {
+                        0
+                    };
                     if let Some(snapshot) =
-                        capture_tmux_history_with_retry(socket, name, include_scrollback).await
+                        capture_tmux_history_with_retry(socket, name, include_scrollback, max_lines)
+                            .await
                     {
                         let total = snapshot.len();
                         let skip = total.saturating_sub(max);
@@ -3064,6 +3142,8 @@ fn capture_tmux_history_blocking(
     socket: &str,
     session: &str,
     include_scrollback: bool,
+    // Lines to request via `-S -N`. Ignored when include_scrollback is false.
+    max_scrollback_lines: usize,
 ) -> Option<Vec<u8>> {
     let targets = [
         format!("{}:0.0", session),
@@ -3081,7 +3161,7 @@ fn capture_tmux_history_blocking(
             .arg("-p")
             .arg("-e");
         if include_scrollback {
-            cmd.arg("-S").arg("-200000");
+            cmd.arg("-S").arg(format!("-{}", max_scrollback_lines));
         }
         cmd.arg("-t").arg(&target);
         let output = cmd.output();
@@ -3098,9 +3178,10 @@ async fn capture_tmux_history(
     socket: String,
     session: String,
     include_scrollback: bool,
+    max_scrollback_lines: usize,
 ) -> Option<Vec<u8>> {
     tokio::task::spawn_blocking(move || {
-        capture_tmux_history_blocking(&socket, &session, include_scrollback)
+        capture_tmux_history_blocking(&socket, &session, include_scrollback, max_scrollback_lines)
     })
     .await
     .ok()
@@ -3117,15 +3198,18 @@ async fn capture_tmux_history_with_retry(
     socket: String,
     session: String,
     include_scrollback: bool,
+    max_scrollback_lines: usize,
 ) -> Option<Vec<u8>> {
     if include_scrollback {
-        return capture_tmux_history(socket, session, true).await;
+        return capture_tmux_history(socket, session, true, max_scrollback_lines).await;
     }
 
     const MAX_ATTEMPTS: usize = 8;
     const RETRY_DELAY_MS: u64 = 120;
     for attempt in 0..MAX_ATTEMPTS {
-        if let Some(snapshot) = capture_tmux_history(socket.clone(), session.clone(), false).await {
+        if let Some(snapshot) =
+            capture_tmux_history(socket.clone(), session.clone(), false, 0).await
+        {
             if snapshot_has_visible_content(&snapshot) || attempt + 1 == MAX_ATTEMPTS {
                 return Some(snapshot);
             }
@@ -3323,8 +3407,11 @@ fn update_alt_screen_state(in_alt_screen: &mut bool, tail: &mut Vec<u8>, chunk: 
     tail.extend_from_slice(&scan[scan.len() - keep..]);
 }
 
-fn cli_defaults_to_frame_mode(cli: CliType) -> bool {
-    matches!(cli, CliType::Codex | CliType::OpenCode)
+fn cli_defaults_to_frame_mode(_cli: CliType) -> bool {
+    // Do not pre-set frame mode based on app identity. The heuristic
+    // (heavy cursor-repositioning ops in output) detects frame-rendering
+    // behavior universally, regardless of which application is running.
+    false
 }
 
 fn should_enable_frame_mode(cursor_ops: u32, erase_ops: u32) -> bool {
@@ -3702,7 +3789,7 @@ mod tests {
 
         tokio::time::sleep(Duration::from_millis(150)).await;
 
-        let snapshot = capture_tmux_history(socket.clone(), session.clone(), true)
+        let snapshot = capture_tmux_history(socket.clone(), session.clone(), true, 1_000)
             .await
             .expect("tmux snapshot");
         let text = String::from_utf8_lossy(&snapshot);
@@ -3939,9 +4026,11 @@ mod tests {
     }
 
     #[test]
-    fn codex_and_opencode_default_to_frame_mode() {
-        assert!(super::cli_defaults_to_frame_mode(CliType::Codex));
-        assert!(super::cli_defaults_to_frame_mode(CliType::OpenCode));
+    fn frame_mode_not_preset_by_app_name() {
+        // frame_render_mode must be detected from observable output patterns,
+        // not pre-set based on which application is being launched.
+        assert!(!super::cli_defaults_to_frame_mode(CliType::Codex));
+        assert!(!super::cli_defaults_to_frame_mode(CliType::OpenCode));
         assert!(!super::cli_defaults_to_frame_mode(CliType::Claude));
         assert!(!super::cli_defaults_to_frame_mode(CliType::Terminal));
     }

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -182,6 +182,9 @@ pub struct PtySession {
 pub struct DaemonState {
     pub sessions: HashMap<String, PtySession>,
     pub mobile_clients: HashMap<SocketAddr, mpsc::Sender<Message>>,
+    /// Mapping from logical mobile sender ID to current socket address.
+    /// Used to evict stale/replaced websocket addresses on reconnect.
+    pub mobile_sender_addrs: HashMap<String, SocketAddr>,
     pub pty_broadcast: broadcast::Sender<(String, Vec<u8>)>,
     pub port: u16, // The actual port the daemon is running on
     pub push_tokens: Vec<PushToken>,
@@ -217,6 +220,7 @@ impl DaemonState {
         Self {
             sessions: HashMap::new(),
             mobile_clients: HashMap::new(),
+            mobile_sender_addrs: HashMap::new(),
             pty_broadcast,
             port,
             push_tokens: Vec::new(),
@@ -1353,9 +1357,33 @@ async fn process_client_msg(
     addr: SocketAddr,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     match msg {
-        ClientMessage::Hello { client_version, .. } => {
+        ClientMessage::Hello {
+            client_version,
+            sender_id,
+        } => {
             // Already sent Welcome on connect, but log the client version
             tracing::debug!("Client hello, version: {}", client_version);
+            if let Some(sender_id) = sender_id
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+            {
+                let replaced_addr = {
+                    let mut st = state.write().await;
+                    match st.mobile_sender_addrs.insert(sender_id.clone(), addr) {
+                        Some(previous) if previous != addr => Some(previous),
+                        _ => None,
+                    }
+                };
+                if let Some(previous_addr) = replaced_addr {
+                    tracing::info!(
+                        sender_id = %sender_id,
+                        previous_addr = %previous_addr,
+                        new_addr = %addr,
+                        "Replacing stale mobile socket for sender_id"
+                    );
+                    evict_mobile_addr(state, previous_addr).await;
+                }
+            }
         }
         ClientMessage::Subscribe { session_id } => {
             tracing::debug!("Client subscribed to session: {}", session_id);
@@ -3398,6 +3426,14 @@ fn build_notification_text(
 async fn cleanup_client_state(state: &SharedState, addr: SocketAddr) {
     let (sessions_to_restore, to_unwatch) = {
         let mut st = state.write().await;
+        let stale_sender_ids: Vec<String> = st
+            .mobile_sender_addrs
+            .iter()
+            .filter_map(|(sender_id, mapped_addr)| (*mapped_addr == addr).then_some(sender_id.clone()))
+            .collect();
+        for sender_id in stale_sender_ids {
+            st.mobile_sender_addrs.remove(&sender_id);
+        }
         st.pending_tui_replay.remove(&addr);
 
         let sessions_to_restore = match st.mobile_views.remove(&addr) {
@@ -3449,6 +3485,19 @@ async fn cleanup_client_state(state: &SharedState, addr: SocketAddr) {
     for session_id in sessions_to_restore {
         restore_pty_size(state, &session_id).await;
     }
+}
+
+/// Evict a stale mobile websocket address and clean all associated view/watch state.
+async fn evict_mobile_addr(state: &SharedState, addr: SocketAddr) {
+    let stale_tx = {
+        let mut st = state.write().await;
+        st.file_rate_limiters.remove(&addr);
+        st.mobile_clients.remove(&addr)
+    };
+    if let Some(tx) = stale_tx {
+        let _ = tx.try_send(Message::Close(None));
+    }
+    cleanup_client_state(state, addr).await;
 }
 
 fn is_path_watched(changed_path: &str, watched: &std::collections::HashSet<String>) -> bool {

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -118,6 +118,8 @@ const DEFAULT_SCROLLBACK_MAX_BYTES: usize = 64 * 1024;
 const ALT_ENTER_SEQS: &[&[u8]] = &[b"\x1b[?1049h", b"\x1b[?1047h", b"\x1b[?47h"];
 const ALT_LEAVE_SEQS: &[&[u8]] = &[b"\x1b[?1049l", b"\x1b[?1047l", b"\x1b[?47l"];
 const ALT_TRACK_TAIL_BYTES: usize = 7;
+const FRAME_CURSOR_THRESHOLD: u32 = 80;
+const FRAME_ERASE_THRESHOLD: u32 = 40;
 
 #[derive(Debug, Clone, Copy)]
 pub struct ResizeRequest {
@@ -149,6 +151,13 @@ pub struct PtySession {
     /// Tail bytes from prior chunk used to detect alt-screen escape sequences
     /// split across PTY read boundaries.
     pub alt_track_tail: Vec<u8>,
+    /// Cumulative count of absolute cursor-position operations (CSI ... H).
+    pub frame_cursor_pos_count: u32,
+    /// Cumulative count of erase-line operations (CSI ... K).
+    pub frame_erase_line_count: u32,
+    /// True for frame-rendered CLIs (full-screen style) even when they don't
+    /// use alternate screen sequences like ?1049h/?1049l.
+    pub frame_render_mode: bool,
     /// Latest accepted resize epoch from mobile (for stale resize rejection).
     pub last_resize_epoch: u64,
     /// Last dimensions acknowledged by the PTY wrapper.
@@ -586,6 +595,7 @@ async fn handle_pty_session(
     let pty_broadcast = {
         let mut cli_tracker = CliTracker::new();
         cli_tracker.update_from_command(&command);
+        let initial_frame_mode = cli_defaults_to_frame_mode(cli_tracker.current());
 
         let mut st = state.write().await;
         st.sessions.insert(
@@ -605,6 +615,9 @@ async fn handle_pty_session(
                 scrollback_max_bytes: DEFAULT_SCROLLBACK_MAX_BYTES,
                 in_alt_screen: false,
                 alt_track_tail: Vec::new(),
+                frame_cursor_pos_count: 0,
+                frame_erase_line_count: 0,
+                frame_render_mode: initial_frame_mode,
                 last_resize_epoch: 0,
                 last_applied_size: None,
             },
@@ -653,6 +666,21 @@ async fn handle_pty_session(
                                                     &mut session.alt_track_tail,
                                                     &bytes,
                                                 );
+                                                let was_frame = session.frame_render_mode;
+                                                update_frame_render_state(
+                                                    &mut session.frame_render_mode,
+                                                    &mut session.frame_cursor_pos_count,
+                                                    &mut session.frame_erase_line_count,
+                                                    &bytes,
+                                                );
+                                                if !was_frame && session.frame_render_mode {
+                                                    tracing::info!(
+                                                        session_id = %session_id,
+                                                        cursor_ops = session.frame_cursor_pos_count,
+                                                        erase_ops = session.frame_erase_line_count,
+                                                        "Detected frame-rendered session (non-alt); suppressing raw scrollback replay on subscribe"
+                                                    );
+                                                }
                                             }
                                         }
 
@@ -1306,15 +1334,15 @@ async fn process_client_msg(
             }
 
             // Collect session state under one lock, then drop it before sending.
-            let (scrollback_bytes, in_alt_screen) =
+            let (scrollback_bytes, render_as_tui) =
                 if let Some(session) = st.sessions.get(&session_id) {
-                    let alt = session.in_alt_screen;
-                    let sb = if !alt && !session.scrollback.is_empty() {
+                    let render_as_tui = session.in_alt_screen || session.frame_render_mode;
+                    let sb = if !render_as_tui && !session.scrollback.is_empty() {
                         Some(session.scrollback.iter().copied().collect::<Vec<u8>>())
                     } else {
                         None
                     };
-                    (sb, alt)
+                    (sb, render_as_tui)
                 } else {
                     (None, false)
                 };
@@ -1337,7 +1365,7 @@ async fn process_client_msg(
             // stale bytes and enter alt-screen mode before resizing.
             let ack = ServerMessage::SubscribeAck {
                 session_id,
-                in_alt_screen,
+                in_alt_screen: render_as_tui,
             };
             if let Ok(text) = serde_json::to_string(&ack) {
                 let _ = tx.send(Message::Text(text)).await;
@@ -2778,6 +2806,73 @@ fn update_alt_screen_state(in_alt_screen: &mut bool, tail: &mut Vec<u8>, chunk: 
     tail.extend_from_slice(&scan[scan.len() - keep..]);
 }
 
+fn cli_defaults_to_frame_mode(cli: CliType) -> bool {
+    matches!(cli, CliType::Codex | CliType::OpenCode)
+}
+
+fn should_enable_frame_mode(cursor_ops: u32, erase_ops: u32) -> bool {
+    cursor_ops >= FRAME_CURSOR_THRESHOLD && erase_ops >= FRAME_ERASE_THRESHOLD
+}
+
+fn scan_frame_sequences(chunk: &[u8]) -> (u32, u32) {
+    let mut cursor_ops = 0u32;
+    let mut erase_ops = 0u32;
+    let mut i = 0usize;
+
+    while i + 2 < chunk.len() {
+        if chunk[i] != 0x1b || chunk[i + 1] != b'[' {
+            i += 1;
+            continue;
+        }
+
+        let mut j = i + 2;
+        while j < chunk.len()
+            && (chunk[j].is_ascii_digit() || chunk[j] == b';' || chunk[j] == b'?')
+        {
+            j += 1;
+        }
+
+        if j >= chunk.len() {
+            break;
+        }
+
+        let final_byte = chunk[j];
+        let params = &chunk[i + 2..j];
+
+        if final_byte == b'H' && (params.is_empty() || params.contains(&b';')) {
+            cursor_ops += 1;
+        } else if final_byte == b'K' {
+            erase_ops += 1;
+        }
+
+        i = j + 1;
+    }
+
+    (cursor_ops, erase_ops)
+}
+
+fn update_frame_render_state(
+    frame_mode: &mut bool,
+    cursor_ops: &mut u32,
+    erase_ops: &mut u32,
+    chunk: &[u8],
+) {
+    if *frame_mode || chunk.is_empty() {
+        return;
+    }
+
+    let (cursor_inc, erase_inc) = scan_frame_sequences(chunk);
+    if cursor_inc == 0 && erase_inc == 0 {
+        return;
+    }
+
+    *cursor_ops = cursor_ops.saturating_add(cursor_inc);
+    *erase_ops = erase_ops.saturating_add(erase_inc);
+    if should_enable_frame_mode(*cursor_ops, *erase_ops) {
+        *frame_mode = true;
+    }
+}
+
 fn build_notification_text(
     cli_type: CliType,
     session_name: &str,
@@ -2948,10 +3043,12 @@ mod tests {
     use super::{
         build_upload_destination_path, is_noop_resize, is_stale_resize_epoch,
         is_windows_reserved_device_name, resolve_resize_reason, sanitize_upload_file_name,
-        should_force_noop_resize, should_ignore_restore_resize, update_alt_screen_state,
+        scan_frame_sequences, should_enable_frame_mode, should_force_noop_resize,
+        should_ignore_restore_resize, update_alt_screen_state, update_frame_render_state,
         PtyResizeReason,
         MAX_UPLOAD_FILE_NAME_BYTES,
     };
+    use crate::detection::CliType;
     use tempfile::TempDir;
 
     #[test]
@@ -3095,5 +3192,45 @@ mod tests {
         assert!(!should_force_noop_resize(PtyResizeReason::DetachRestore));
         assert!(!should_force_noop_resize(PtyResizeReason::KeyboardOverlay));
         assert!(!should_force_noop_resize(PtyResizeReason::Unknown));
+    }
+
+    #[test]
+    fn frame_sequence_scanner_counts_cursor_and_erase_ops() {
+        let chunk = b"\x1b[10;2HHello\x1b[K\x1b[H\x1b[2K";
+        let (cursor, erase) = scan_frame_sequences(chunk);
+        assert_eq!(cursor, 2);
+        assert_eq!(erase, 2);
+    }
+
+    #[test]
+    fn frame_mode_threshold_requires_heavy_cursor_and_erase_usage() {
+        assert!(!should_enable_frame_mode(79, 40));
+        assert!(!should_enable_frame_mode(80, 39));
+        assert!(should_enable_frame_mode(80, 40));
+        assert!(should_enable_frame_mode(400, 200));
+    }
+
+    #[test]
+    fn frame_mode_update_flips_after_threshold() {
+        let mut frame_mode = false;
+        let mut cursor = 0u32;
+        let mut erase = 0u32;
+        let chunk = b"\x1b[10;2H\x1b[K";
+
+        for _ in 0..79 {
+            update_frame_render_state(&mut frame_mode, &mut cursor, &mut erase, chunk);
+        }
+        assert!(!frame_mode);
+
+        update_frame_render_state(&mut frame_mode, &mut cursor, &mut erase, chunk);
+        assert!(frame_mode);
+    }
+
+    #[test]
+    fn codex_and_opencode_default_to_frame_mode() {
+        assert!(super::cli_defaults_to_frame_mode(CliType::Codex));
+        assert!(super::cli_defaults_to_frame_mode(CliType::OpenCode));
+        assert!(!super::cli_defaults_to_frame_mode(CliType::Claude));
+        assert!(!super::cli_defaults_to_frame_mode(CliType::Terminal));
     }
 }

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -1187,12 +1187,16 @@ async fn spawn_session_from_mobile(
     // Without this, the spawned terminal inherits the daemon's CWD,
     // which is wherever the daemon was launched from (often the project dir).
     let home_dir_buf = dirs_next::home_dir();
-    let effective_working_dir: Option<&str> = working_dir.or_else(|| {
-        home_dir_buf.as_ref().and_then(|p| p.to_str())
-    });
+    let effective_working_dir: Option<&str> =
+        working_dir.or_else(|| home_dir_buf.as_ref().and_then(|p| p.to_str()));
 
-    let wrap_cmd =
-        build_wrap_shell_command(&mobilecli_bin, session_name, command, args, effective_working_dir);
+    let wrap_cmd = build_wrap_shell_command(
+        &mobilecli_bin,
+        session_name,
+        command,
+        args,
+        effective_working_dir,
+    );
     let shell_args = shell_args_for_command(&shell, &wrap_cmd);
 
     let mut cmd = if let Some(ref terminal) = terminal {
@@ -1573,13 +1577,8 @@ async fn process_client_msg(
                         0
                     };
                     if let Some(snapshot) =
-                        capture_tmux_history_with_retry(
-                            socket,
-                            name,
-                            include_scrollback,
-                            max_lines,
-                        )
-                        .await
+                        capture_tmux_history_with_retry(socket, name, include_scrollback, max_lines)
+                            .await
                     {
                         let total_bytes = snapshot.len();
                         let skip = total_bytes.saturating_sub(max_bytes);
@@ -2030,38 +2029,39 @@ async fn process_client_msg(
                 }
             };
 
-            let (data, total_bytes) =
-                if let Some((socket, name, max, include_scrollback)) = tmux_capture_req {
-                    // On-demand history requests use the full depth so users can
-                    // retrieve the maximum available scrollback from tmux.
-                    let max_lines = if include_scrollback {
-                        HISTORY_SCROLLBACK_LINES
-                    } else {
-                        0
-                    };
-                    if let Some(snapshot) =
-                        capture_tmux_history_with_retry(socket, name, include_scrollback, max_lines)
-                            .await
-                    {
-                        let total = snapshot.len();
-                        let skip = total.saturating_sub(max);
-                        (BASE64.encode(&snapshot[skip..]), total)
-                    } else {
-                        tracing::debug!(
-                            session_id = %session_id,
-                            fallback_total_bytes = fallback_total_bytes,
-                            "tmux capture-pane unavailable, falling back to daemon scrollback replay"
-                        );
-                        (BASE64.encode(&fallback_bytes), fallback_total_bytes)
-                    }
+            let (data, total_bytes) = if let Some((socket, name, max, include_scrollback)) =
+                tmux_capture_req
+            {
+                // On-demand history requests use the full depth so users can
+                // retrieve the maximum available scrollback from tmux.
+                let max_lines = if include_scrollback {
+                    HISTORY_SCROLLBACK_LINES
+                } else {
+                    0
+                };
+                if let Some(snapshot) =
+                    capture_tmux_history_with_retry(socket, name, include_scrollback, max_lines)
+                        .await
+                {
+                    let total = snapshot.len();
+                    let skip = total.saturating_sub(max);
+                    (BASE64.encode(&snapshot[skip..]), total)
                 } else {
                     tracing::debug!(
                         session_id = %session_id,
                         fallback_total_bytes = fallback_total_bytes,
-                        "Using daemon scrollback replay for session_history"
+                        "tmux capture-pane unavailable, falling back to daemon scrollback replay"
                     );
                     (BASE64.encode(&fallback_bytes), fallback_total_bytes)
-                };
+                }
+            } else {
+                tracing::debug!(
+                    session_id = %session_id,
+                    fallback_total_bytes = fallback_total_bytes,
+                    "Using daemon scrollback replay for session_history"
+                );
+                (BASE64.encode(&fallback_bytes), fallback_total_bytes)
+            };
 
             let msg = ServerMessage::SessionHistory {
                 session_id,
@@ -3553,7 +3553,9 @@ async fn cleanup_client_state(state: &SharedState, addr: SocketAddr) {
         let stale_sender_ids: Vec<String> = st
             .mobile_sender_addrs
             .iter()
-            .filter_map(|(sender_id, mapped_addr)| (*mapped_addr == addr).then_some(sender_id.clone()))
+            .filter_map(|(sender_id, mapped_addr)| {
+                (*mapped_addr == addr).then_some(sender_id.clone())
+            })
             .collect();
         for sender_id in stale_sender_ids {
             st.mobile_sender_addrs.remove(&sender_id);
@@ -3720,10 +3722,10 @@ mod tests {
         is_stale_resize_epoch, is_windows_reserved_device_name, resolve_resize_reason,
         sanitize_upload_file_name, scan_frame_sequences, should_enable_frame_mode,
         should_force_noop_resize, should_ignore_resize_without_viewers,
-        should_ignore_restore_resize, should_treat_as_tui_for_mobile, strip_terminal_report_sequences,
-        strip_terminal_report_sequences_stateful, update_alt_screen_state,
-        update_frame_render_state, DaemonState, PtyResizeReason, PtySession,
-        DEFAULT_SCROLLBACK_MAX_BYTES, MAX_UPLOAD_FILE_NAME_BYTES,
+        should_ignore_restore_resize, should_treat_as_tui_for_mobile,
+        strip_terminal_report_sequences, strip_terminal_report_sequences_stateful,
+        update_alt_screen_state, update_frame_render_state, DaemonState, PtyResizeReason,
+        PtySession, DEFAULT_SCROLLBACK_MAX_BYTES, MAX_UPLOAD_FILE_NAME_BYTES,
     };
     use crate::detection::{CliTracker, CliType};
     use base64::Engine as _;

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -139,6 +139,10 @@ pub struct PtySession {
     pub session_id: String,
     /// Execution runtime used by the wrapper (`pty` or `tmux`).
     pub runtime: String,
+    /// tmux socket label (when runtime=tmux)
+    pub tmux_socket: Option<String>,
+    /// tmux session name (when runtime=tmux)
+    pub tmux_session: Option<String>,
     pub name: String,
     pub command: String,
     pub project_path: String,
@@ -597,6 +601,13 @@ async fn handle_pty_session(
     let command = reg_msg["command"].as_str().unwrap_or("shell").to_string();
     let project_path = reg_msg["project_path"].as_str().unwrap_or("").to_string();
     let runtime = reg_msg["runtime"].as_str().unwrap_or("pty").to_lowercase();
+    let (tmux_socket, tmux_session) = if runtime == "tmux" {
+        let token = sanitize_tmux_token(&session_id);
+        let name = format!("mcli-{}", token);
+        (Some(name.clone()), Some(name))
+    } else {
+        (None, None)
+    };
 
     tracing::info!(
         "PTY session registered: {} ({}) runtime={}",
@@ -620,6 +631,8 @@ async fn handle_pty_session(
             PtySession {
                 session_id: session_id.clone(),
                 runtime: runtime.clone(),
+                tmux_socket,
+                tmux_session,
                 name: name.clone(),
                 command,
                 project_path,
@@ -1353,24 +1366,45 @@ async fn process_client_msg(
             }
 
             // Collect session state under one lock, then drop it before sending.
-            let (scrollback_bytes, render_as_tui, queue_deferred_replay, scrollback_len) =
-                if let Some(session) = st.sessions.get(&session_id) {
-                    let render_as_tui = session.in_alt_screen || session.frame_render_mode;
-                    let has_scrollback = !session.scrollback.is_empty();
-                    let sb = if !render_as_tui && has_scrollback {
-                        Some(session.scrollback.iter().copied().collect::<Vec<u8>>())
-                    } else {
-                        None
-                    };
-                    (
-                        sb,
-                        render_as_tui,
-                        render_as_tui && has_scrollback,
-                        session.scrollback.len(),
-                    )
+            let (
+                scrollback_bytes,
+                render_as_tui,
+                queue_deferred_replay,
+                scrollback_len,
+                runtime,
+                tmux_snapshot_req,
+            ) = if let Some(session) = st.sessions.get(&session_id) {
+                let render_as_tui = session.in_alt_screen || session.frame_render_mode;
+                let has_scrollback = !session.scrollback.is_empty();
+                let runtime = session.runtime.clone();
+                let tmux_snapshot_req = if runtime == "tmux" {
+                    match (&session.tmux_socket, &session.tmux_session) {
+                        (Some(socket), Some(name)) => {
+                            Some((socket.clone(), name.clone(), session.scrollback_max_bytes))
+                        }
+                        _ => None,
+                    }
                 } else {
-                    (None, false, false, 0)
+                    None
                 };
+                let sb = if runtime != "tmux" && !render_as_tui && has_scrollback {
+                    Some(session.scrollback.iter().copied().collect::<Vec<u8>>())
+                } else {
+                    None
+                };
+                (
+                    sb,
+                    render_as_tui,
+                    // tmux sessions use capture-pane snapshots; raw deferred replay
+                    // of daemon scrollback corrupts frame TUIs on reconnect.
+                    runtime != "tmux" && render_as_tui && has_scrollback,
+                    session.scrollback.len(),
+                    runtime,
+                    tmux_snapshot_req,
+                )
+            } else {
+                (None, false, false, 0, "pty".to_string(), None)
+            };
 
             if queue_deferred_replay {
                 st.pending_tui_replay
@@ -1390,6 +1424,7 @@ async fn process_client_msg(
             tracing::debug!(
                 session_id = %session_id,
                 addr = %addr,
+                runtime = %runtime,
                 render_as_tui,
                 queue_deferred_replay,
                 scrollback_len,
@@ -1408,6 +1443,22 @@ async fn process_client_msg(
                 };
                 if let Ok(text) = serde_json::to_string(&msg) {
                     let _ = tx.send(Message::Text(text)).await;
+                }
+            }
+
+            if let Some((socket, name, max_bytes)) = tmux_snapshot_req {
+                if let Some(snapshot) = capture_tmux_history(socket, name).await {
+                    let total_bytes = snapshot.len();
+                    let skip = total_bytes.saturating_sub(max_bytes);
+                    let bytes = &snapshot[skip..];
+                    let msg = ServerMessage::SessionHistory {
+                        session_id: session_id.clone(),
+                        data: BASE64.encode(bytes),
+                        total_bytes,
+                    };
+                    if let Ok(text) = serde_json::to_string(&msg) {
+                        let _ = tx.send(Message::Text(text)).await;
+                    }
                 }
             }
 
@@ -1771,18 +1822,34 @@ async fn process_client_msg(
             session_id,
             max_bytes,
         } => {
-            let (data, total_bytes) = {
+            let mut tmux_capture_req: Option<(String, String, usize)> = None;
+            let (fallback_bytes, fallback_total_bytes) = {
                 let st = state.read().await;
                 if let Some(session) = st.sessions.get(&session_id) {
                     let max = max_bytes.unwrap_or(session.scrollback_max_bytes);
-                    let total = session.scrollback.len();
-                    let skip = total.saturating_sub(max);
-                    // VecDeque doesn't support direct slicing, so collect the tail
-                    let bytes: Vec<u8> = session.scrollback.iter().skip(skip).copied().collect();
-                    (BASE64.encode(&bytes), total)
+                    if session.runtime == "tmux" {
+                        if let (Some(socket), Some(name)) =
+                            (session.tmux_socket.clone(), session.tmux_session.clone())
+                        {
+                            tmux_capture_req = Some((socket, name, max));
+                        }
+                    }
+                    tail_scrollback_bytes(session, max)
                 } else {
-                    (String::new(), 0)
+                    (Vec::new(), 0)
                 }
+            };
+
+            let (data, total_bytes) = if let Some((socket, name, max)) = tmux_capture_req {
+                if let Some(snapshot) = capture_tmux_history(socket, name).await {
+                    let total = snapshot.len();
+                    let skip = total.saturating_sub(max);
+                    (BASE64.encode(&snapshot[skip..]), total)
+                } else {
+                    (BASE64.encode(&fallback_bytes), fallback_total_bytes)
+                }
+            } else {
+                (BASE64.encode(&fallback_bytes), fallback_total_bytes)
             };
 
             let msg = ServerMessage::SessionHistory {
@@ -2762,7 +2829,7 @@ async fn broadcast_pty_resized(
 
             if !replay_addrs.is_empty() {
                 if let Some(session) = st.sessions.get(session_id) {
-                    if !session.scrollback.is_empty() {
+                    if session.runtime != "tmux" && !session.scrollback.is_empty() {
                         replay_scrollback_len = session.scrollback.len();
                         let bytes: Vec<u8> = session.scrollback.iter().copied().collect();
                         let replay_msg = ServerMessage::PtyBytes {
@@ -2770,6 +2837,11 @@ async fn broadcast_pty_resized(
                             data: BASE64.encode(&bytes),
                         };
                         replay_payload = serde_json::to_string(&replay_msg).ok();
+                    } else if session.runtime == "tmux" {
+                        tracing::debug!(
+                            session_id = %session_id,
+                            "Skipping deferred raw replay for tmux runtime; mobile will request capture-pane snapshot"
+                        );
                     }
                 }
 
@@ -2866,6 +2938,67 @@ fn truncate_to_max_chars(input: &mut String, max_chars: usize) {
     }
     let trimmed: String = input.chars().skip(len - max_chars).collect();
     *input = trimmed;
+}
+
+fn sanitize_tmux_token(raw: &str) -> String {
+    let mut out: String = raw
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    if out.is_empty() {
+        out.push_str("session");
+    }
+    out
+}
+
+fn tail_scrollback_bytes(session: &PtySession, max_bytes: usize) -> (Vec<u8>, usize) {
+    let total = session.scrollback.len();
+    let skip = total.saturating_sub(max_bytes);
+    let bytes: Vec<u8> = session.scrollback.iter().skip(skip).copied().collect();
+    (bytes, total)
+}
+
+fn capture_tmux_history_blocking(socket: &str, session: &str) -> Option<Vec<u8>> {
+    let targets = [
+        format!("{}:0.0", session),
+        format!("{}:0", session),
+        session.to_string(),
+    ];
+    for target in targets {
+        let output = std::process::Command::new("tmux")
+            .arg("-L")
+            .arg(socket)
+            .arg("-f")
+            .arg("/dev/null")
+            .env_remove("TMUX")
+            .arg("capture-pane")
+            .arg("-p")
+            .arg("-e")
+            .arg("-S")
+            .arg("-200000")
+            .arg("-t")
+            .arg(&target)
+            .output();
+        if let Ok(out) = output {
+            if out.status.success() {
+                return Some(out.stdout);
+            }
+        }
+    }
+    None
+}
+
+async fn capture_tmux_history(socket: String, session: String) -> Option<Vec<u8>> {
+    tokio::task::spawn_blocking(move || capture_tmux_history_blocking(&socket, &session))
+        .await
+        .ok()
+        .flatten()
 }
 
 fn should_ignore_restore_resize(
@@ -3187,7 +3320,7 @@ async fn send_push_notifications(tokens: &[PushToken], title: &str, body: &str, 
 #[cfg(test)]
 mod tests {
     use super::{
-        broadcast_pty_resized, build_upload_destination_path, is_noop_resize,
+        broadcast_pty_resized, build_upload_destination_path, capture_tmux_history, is_noop_resize,
         is_stale_resize_epoch, is_windows_reserved_device_name, resolve_resize_reason,
         sanitize_upload_file_name, scan_frame_sequences, should_enable_frame_mode,
         should_force_noop_resize, should_ignore_restore_resize, update_alt_screen_state,
@@ -3208,6 +3341,59 @@ mod tests {
     fn default_scrollback_is_large_enough_for_frame_clis() {
         assert_eq!(DEFAULT_SCROLLBACK_MAX_BYTES, 2 * 1024 * 1024);
         assert!(DEFAULT_SCROLLBACK_MAX_BYTES > 64 * 1024);
+    }
+
+    #[tokio::test]
+    async fn tmux_capture_history_returns_snapshot_text() {
+        if which::which("tmux").is_err() {
+            return;
+        }
+
+        let token = &uuid::Uuid::new_v4().to_string()[..8];
+        let socket = format!("mcli-test-{}-sock", token);
+        let session = format!("mcli-test-{}-session", token);
+
+        let spawn = std::process::Command::new("tmux")
+            .arg("-L")
+            .arg(&socket)
+            .arg("-f")
+            .arg("/dev/null")
+            .env_remove("TMUX")
+            .args([
+                "new-session",
+                "-d",
+                "-s",
+                &session,
+                "printf CAPTURE_OK; sleep 2",
+            ])
+            .output()
+            .expect("spawn tmux test session");
+        assert!(
+            spawn.status.success(),
+            "failed to spawn tmux test session: {}",
+            String::from_utf8_lossy(&spawn.stderr)
+        );
+
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        let snapshot = capture_tmux_history(socket.clone(), session.clone())
+            .await
+            .expect("tmux snapshot");
+        let text = String::from_utf8_lossy(&snapshot);
+        assert!(
+            text.contains("CAPTURE_OK"),
+            "snapshot missing expected marker: {}",
+            text
+        );
+
+        let _ = std::process::Command::new("tmux")
+            .arg("-L")
+            .arg(&socket)
+            .arg("-f")
+            .arg("/dev/null")
+            .env_remove("TMUX")
+            .arg("kill-server")
+            .status();
     }
 
     #[test]
@@ -3428,6 +3614,8 @@ mod tests {
                 PtySession {
                     session_id: session_id.clone(),
                     runtime: "pty".to_string(),
+                    tmux_socket: None,
+                    tmux_session: None,
                     name: "Codex".to_string(),
                     command: "codex".to_string(),
                     project_path: "/tmp".to_string(),

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -136,8 +136,63 @@ const HISTORY_SCROLLBACK_LINES: usize = 200_000;
 const ALT_ENTER_SEQS: &[&[u8]] = &[b"\x1b[?1049h", b"\x1b[?1047h", b"\x1b[?47h"];
 const ALT_LEAVE_SEQS: &[&[u8]] = &[b"\x1b[?1049l", b"\x1b[?1047l", b"\x1b[?47l"];
 const ALT_TRACK_TAIL_BYTES: usize = 7;
-const FRAME_CURSOR_THRESHOLD: u32 = 80;
-const FRAME_ERASE_THRESHOLD: u32 = 40;
+const SNAPSHOT_CHUNK_BYTES: usize = 48 * 1024;
+const CLIENT_CAP_ATTACH_V2: u32 = 1 << 0;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AttachProtocolMode {
+    V1,
+    V2,
+}
+
+impl AttachProtocolMode {
+    fn from_env() -> Self {
+        match std::env::var("MOBILECLI_ATTACH_PROTOCOL")
+            .ok()
+            .map(|value| value.trim().to_ascii_lowercase())
+            .as_deref()
+        {
+            Some("v1") => Self::V1,
+            Some("v2") => Self::V2,
+            _ => Self::V2,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::V1 => "v1",
+            Self::V2 => "v2",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct OverhaulFlags {
+    pub attach_protocol: AttachProtocolMode,
+    pub enable_local_echo: bool,
+    pub resize_simplified: bool,
+}
+
+impl OverhaulFlags {
+    pub fn from_env() -> Self {
+        Self {
+            attach_protocol: AttachProtocolMode::from_env(),
+            enable_local_echo: env_flag("MOBILECLI_ENABLE_LOCAL_ECHO", false),
+            resize_simplified: env_flag("MOBILECLI_RESIZE_SIMPLIFIED", true),
+        }
+    }
+}
+
+fn env_flag(name: &str, default: bool) -> bool {
+    match std::env::var(name) {
+        Ok(raw) => match raw.trim().to_ascii_lowercase().as_str() {
+            "1" | "true" | "yes" | "on" => true,
+            "0" | "false" | "no" | "off" => false,
+            _ => default,
+        },
+        Err(_) => default,
+    }
+}
 
 #[derive(Debug, Clone, Copy)]
 pub struct ResizeRequest {
@@ -175,17 +230,12 @@ pub struct PtySession {
     /// Tail bytes from prior chunk used to detect alt-screen escape sequences
     /// split across PTY read boundaries.
     pub alt_track_tail: Vec<u8>,
-    /// Cumulative count of absolute cursor-position operations (CSI ... H).
-    pub frame_cursor_pos_count: u32,
-    /// Cumulative count of erase-line operations (CSI ... K).
-    pub frame_erase_line_count: u32,
-    /// True for frame-rendered CLIs (full-screen style) even when they don't
-    /// use alternate screen sequences like ?1049h/?1049l.
-    pub frame_render_mode: bool,
     /// Latest accepted resize epoch from mobile (for stale resize rejection).
     pub last_resize_epoch: u64,
     /// Last dimensions acknowledged by the PTY wrapper.
     pub last_applied_size: Option<(u16, u16)>,
+    /// Sequence number for live PTY chunks (Phase 0 observability scaffold).
+    pub live_seq: u64,
     /// Tail for raw mobile input filtering to handle escape sequences split
     /// across websocket messages.
     pub raw_input_tail: Vec<u8>,
@@ -194,18 +244,19 @@ pub struct PtySession {
 /// Daemon shared state
 pub struct DaemonState {
     pub sessions: HashMap<String, PtySession>,
+    pub overhaul_flags: OverhaulFlags,
+    pub next_attach_id: u64,
     pub mobile_clients: HashMap<SocketAddr, mpsc::Sender<Message>>,
+    pub mobile_client_capabilities: HashMap<SocketAddr, u32>,
+    pub mobile_attach_ids: HashMap<SocketAddr, HashMap<String, u64>>,
     /// Mapping from logical mobile sender ID to current socket address.
     /// Used to evict stale/replaced websocket addresses on reconnect.
     pub mobile_sender_addrs: HashMap<String, SocketAddr>,
-    pub pty_broadcast: broadcast::Sender<(String, Vec<u8>)>,
+    pub pty_broadcast: broadcast::Sender<(String, u64, Vec<u8>)>,
     pub port: u16, // The actual port the daemon is running on
     pub push_tokens: Vec<PushToken>,
     pub mobile_views: HashMap<SocketAddr, std::collections::HashSet<String>>,
     pub session_view_counts: HashMap<String, usize>,
-    /// Sessions that should receive one deferred replay after first
-    /// post-subscribe PTY resize ack (per mobile client).
-    pub pending_tui_replay: HashMap<SocketAddr, std::collections::HashSet<String>>,
     pub file_system: std::sync::Arc<FileSystemService>,
     pub file_watch_subscriptions: HashMap<SocketAddr, std::collections::HashSet<String>>,
     pub file_watch_counts: HashMap<String, usize>,
@@ -232,14 +283,17 @@ impl DaemonState {
 
         Self {
             sessions: HashMap::new(),
+            overhaul_flags: OverhaulFlags::from_env(),
+            next_attach_id: 1,
             mobile_clients: HashMap::new(),
+            mobile_client_capabilities: HashMap::new(),
+            mobile_attach_ids: HashMap::new(),
             mobile_sender_addrs: HashMap::new(),
             pty_broadcast,
             port,
             push_tokens: Vec::new(),
             mobile_views: HashMap::new(),
             session_view_counts: HashMap::new(),
-            pending_tui_replay: HashMap::new(),
             file_system,
             file_watch_subscriptions: HashMap::new(),
             file_watch_counts: HashMap::new(),
@@ -266,6 +320,16 @@ pub async fn run(port: u16) -> std::io::Result<()> {
     std::fs::write(&port_path, port.to_string())?;
 
     let state: SharedState = Arc::new(RwLock::new(DaemonState::new(port)));
+    {
+        let st = state.read().await;
+        tracing::info!(
+            target: "overhaul.phase0",
+            attach_protocol = st.overhaul_flags.attach_protocol.as_str(),
+            enable_local_echo = st.overhaul_flags.enable_local_echo,
+            resize_simplified = st.overhaul_flags.resize_simplified,
+            "Loaded terminal overhaul Phase 0 flags"
+        );
+    }
 
     // Limit concurrent connections to prevent resource exhaustion
     let conn_limit = Arc::new(tokio::sync::Semaphore::new(64));
@@ -551,11 +615,35 @@ async fn handle_mobile_client(
             // PTY output
             result = pty_rx.recv() => {
                 match result {
-                    Ok((session_id, data)) => {
-                        let msg = ServerMessage::PtyBytes {
-                            session_id,
-                            data: BASE64.encode(&data),
+                    Ok((session_id, seq, data)) => {
+                        let (flags, capabilities, attach_id) = {
+                            let st = state.read().await;
+                            let caps = st.mobile_client_capabilities.get(&addr).copied().unwrap_or(0);
+                            let attach_id = st
+                                .mobile_attach_ids
+                                .get(&addr)
+                                .and_then(|sessions| sessions.get(&session_id).copied());
+                            (st.overhaul_flags, caps, attach_id)
                         };
+
+                        let msg = if should_use_attach_v2(flags, capabilities) {
+                            let Some(attach_id) = attach_id else {
+                                continue;
+                            };
+                            ServerMessage::PtyChunk {
+                                session_id,
+                                attach_id,
+                                seq,
+                                data: BASE64.encode(&data),
+                                timestamp_ms: Utc::now().timestamp_millis().max(0) as u64,
+                            }
+                        } else {
+                            ServerMessage::PtyBytes {
+                                session_id,
+                                data: BASE64.encode(&data),
+                            }
+                        };
+
                         if tx.send(Message::Text(serde_json::to_string(&msg)?)).await.is_err() {
                             break;
                         }
@@ -643,7 +731,6 @@ async fn handle_pty_session(
     let pty_broadcast = {
         let mut cli_tracker = CliTracker::new();
         cli_tracker.update_from_command(&command);
-        let initial_frame_mode = cli_defaults_to_frame_mode(cli_tracker.current());
 
         let mut st = state.write().await;
         st.sessions.insert(
@@ -666,11 +753,9 @@ async fn handle_pty_session(
                 scrollback_max_bytes: DEFAULT_SCROLLBACK_MAX_BYTES,
                 in_alt_screen: false,
                 alt_track_tail: Vec::new(),
-                frame_cursor_pos_count: 0,
-                frame_erase_line_count: 0,
-                frame_render_mode: initial_frame_mode,
                 last_resize_epoch: 0,
                 last_applied_size: None,
+                live_seq: 0,
                 raw_input_tail: Vec::new(),
             },
         );
@@ -699,12 +784,13 @@ async fn handle_pty_session(
                             if msg["type"].as_str() == Some("pty_output") {
                                 if let Some(data) = msg["data"].as_str() {
                                     if let Ok(bytes) = BASE64.decode(data) {
-                                        let _ = pty_broadcast.send((session_id.clone(), bytes.clone()));
-
                                         // Accumulate scrollback and track render state.
+                                        let mut live_seq: Option<u64> = None;
                                         {
                                             let mut st = state.write().await;
                                             if let Some(session) = st.sessions.get_mut(&session_id) {
+                                                session.live_seq = session.live_seq.saturating_add(1);
+                                                live_seq = Some(session.live_seq);
                                                 session.scrollback.extend(bytes.iter().copied());
                                                 // Truncate from front if over limit (VecDeque is O(1) per pop)
                                                 while session.scrollback.len() > session.scrollback_max_bytes {
@@ -727,23 +813,20 @@ async fn handle_pty_session(
                                                         &bytes,
                                                     );
                                                 }
-                                                let was_frame = session.frame_render_mode;
-                                                update_frame_render_state(
-                                                    &mut session.frame_render_mode,
-                                                    &mut session.frame_cursor_pos_count,
-                                                    &mut session.frame_erase_line_count,
-                                                    &bytes,
-                                                );
-                                                if !was_frame && session.frame_render_mode {
-                                                    tracing::info!(
-                                                        session_id = %session_id,
-                                                        cursor_ops = session.frame_cursor_pos_count,
-                                                        erase_ops = session.frame_erase_line_count,
-                                                        "Detected frame-rendered session (non-alt); suppressing raw scrollback replay on subscribe"
-                                                    );
-                                                }
                                             }
                                         }
+                                        if let Some(seq) = live_seq {
+                                            tracing::trace!(
+                                                target: "overhaul.sequence",
+                                                session_id = %session_id,
+                                                seq,
+                                                chunk_bytes = bytes.len(),
+                                                "Forwarding live PTY chunk"
+                                            );
+                                        }
+                                        let seq = live_seq.unwrap_or(0);
+                                        let _ =
+                                            pty_broadcast.send((session_id.clone(), seq, bytes.clone()));
 
                                         let text = String::from_utf8_lossy(&bytes);
                                         let normalized_chunk = strip_ansi_and_normalize(&text);
@@ -848,7 +931,16 @@ async fn handle_pty_session(
                         }
                     }
                     Some(Ok(Message::Binary(data))) => {
-                        let _ = pty_broadcast.send((session_id.clone(), data));
+                        let seq = {
+                            let mut st = state.write().await;
+                            if let Some(session) = st.sessions.get_mut(&session_id) {
+                                session.live_seq = session.live_seq.saturating_add(1);
+                                session.live_seq
+                            } else {
+                                0
+                            }
+                        };
+                        let _ = pty_broadcast.send((session_id.clone(), seq, data));
                     }
                     Some(Ok(Message::Close(_))) | None => break,
                     _ => {}
@@ -899,6 +991,7 @@ async fn handle_pty_session(
                         }
                         if coalesced > 0 {
                             tracing::debug!(
+                                target: "overhaul.resize",
                                 session_id = %session_id,
                                 coalesced,
                                 cols = req.cols,
@@ -932,7 +1025,7 @@ async fn handle_pty_session(
     let was_present = {
         let mut st = state.write().await;
         if st.sessions.remove(&session_id).is_some() {
-            clear_pending_tui_replay_for_session(&mut st, &session_id);
+            clear_mobile_attach_for_session(&mut st, &session_id);
             // Notify about session end
             let msg = ServerMessage::SessionEnded {
                 session_id: session_id.clone(),
@@ -1394,6 +1487,7 @@ async fn process_client_msg(
         ClientMessage::Hello {
             client_version,
             sender_id,
+            client_capabilities,
         } => {
             // Already sent Welcome on connect, but log the client version
             tracing::debug!("Client hello, version: {}", client_version);
@@ -1418,45 +1512,66 @@ async fn process_client_msg(
                     evict_mobile_addr(state, previous_addr).await;
                 }
             }
+            if let Some(capabilities) = client_capabilities {
+                let mut st = state.write().await;
+                st.mobile_client_capabilities.insert(addr, capabilities);
+                tracing::debug!(
+                    addr = %addr,
+                    capabilities,
+                    supports_attach_v2 = client_supports_attach_v2(capabilities),
+                    "Registered mobile client capabilities"
+                );
+            }
         }
-        ClientMessage::Subscribe { session_id } => {
+        ClientMessage::Subscribe {
+            session_id,
+            last_seen_seq,
+            client_capabilities,
+        } => {
             tracing::debug!("Client subscribed to session: {}", session_id);
+            let attach_started = std::time::Instant::now();
             let mut st = state.write().await;
+            if let Some(capabilities) = client_capabilities {
+                st.mobile_client_capabilities.insert(addr, capabilities);
+            }
+            let attach_id = st.next_attach_id;
+            st.next_attach_id = st.next_attach_id.saturating_add(1);
+            let overhaul_flags = st.overhaul_flags;
+            let capabilities = st
+                .mobile_client_capabilities
+                .get(&addr)
+                .copied()
+                .unwrap_or(0);
+            let use_attach_v2 = should_use_attach_v2(overhaul_flags, capabilities);
 
             // Collect session state under one lock, then drop it before sending.
             let (
                 scrollback_bytes,
                 render_as_tui,
                 mobile_in_alt_screen,
-                queue_deferred_replay,
                 scrollback_len,
                 runtime,
                 tmux_snapshot_req,
-                tmux_fallback_bytes,
+                initial_live_seq,
+                ready_cols,
+                ready_rows,
             ) = if let Some(session) = st.sessions.get(&session_id) {
-                let render_as_tui = should_treat_as_tui_for_mobile(
-                    &session.runtime,
-                    session.in_alt_screen,
-                    session.frame_render_mode,
-                );
-                let mobile_in_alt_screen = should_mobile_enter_alt_screen(
-                    &session.runtime,
-                    session.in_alt_screen,
-                    session.frame_render_mode,
-                );
+                let render_as_tui =
+                    should_treat_as_tui_for_mobile(&session.runtime, session.in_alt_screen);
+                let mobile_in_alt_screen =
+                    should_mobile_enter_alt_screen(&session.runtime, session.in_alt_screen);
                 let has_scrollback = !session.scrollback.is_empty();
                 let runtime = session.runtime.clone();
-                // tmux sessions always replay from capture-pane. For frame-rendering
-                // CLIs we request only the visible pane; for text CLIs we include
-                // deeper scrollback.
-                let frame_render = session.frame_render_mode;
+                // tmux sessions always replay from capture-pane. Alternate-screen
+                // sessions replay only the visible pane; main-screen sessions may
+                // include scrollback.
                 let tmux_snapshot_req = if runtime == "tmux" {
                     match (&session.tmux_socket, &session.tmux_session) {
                         (Some(socket), Some(name)) => Some((
                             socket.clone(),
                             name.clone(),
                             session.scrollback_max_bytes,
-                            !frame_render,
+                            !session.in_alt_screen,
                         )),
                         _ => None,
                     }
@@ -1468,56 +1583,70 @@ async fn process_client_msg(
                 } else {
                     None
                 };
-                // Daemon in-memory fallback when capture-pane is unavailable
-                // (socket startup race, etc.).
-                let tmux_fallback = if runtime == "tmux" && has_scrollback {
-                    Some(session.scrollback.iter().copied().collect::<Vec<u8>>())
-                } else {
-                    None
-                };
+                let (ready_cols, ready_rows) = session.last_applied_size.unwrap_or((0, 0));
                 (
                     sb,
                     render_as_tui,
                     mobile_in_alt_screen,
-                    // tmux sessions use capture-pane snapshots; raw deferred replay
-                    // of daemon scrollback corrupts TUIs on reconnect.
-                    runtime != "tmux" && render_as_tui && has_scrollback,
                     session.scrollback.len(),
                     runtime,
                     tmux_snapshot_req,
-                    tmux_fallback,
+                    session.live_seq,
+                    ready_cols,
+                    ready_rows,
                 )
             } else {
-                (None, false, false, false, 0, "pty".to_string(), None, None)
+                (None, false, false, 0, "pty".to_string(), None, 0, 0, 0)
             };
 
-            if queue_deferred_replay {
-                st.pending_tui_replay
-                    .entry(addr)
-                    .or_default()
-                    .insert(session_id.clone());
-            } else {
-                let mut remove_entry = false;
-                if let Some(pending) = st.pending_tui_replay.get_mut(&addr) {
-                    pending.remove(&session_id);
-                    remove_entry = pending.is_empty();
-                }
-                if remove_entry {
-                    st.pending_tui_replay.remove(&addr);
-                }
-            }
             tracing::debug!(
                 session_id = %session_id,
                 addr = %addr,
+                attach_id,
                 runtime = %runtime,
+                capabilities,
+                use_attach_v2,
+                last_seen_seq = ?last_seen_seq,
                 render_as_tui,
                 mobile_in_alt_screen,
-                queue_deferred_replay,
                 scrollback_len,
                 text_replay_bytes = scrollback_bytes.as_ref().map(|b| b.len()).unwrap_or(0),
                 "Subscribe replay decision"
             );
             drop(st);
+            tracing::info!(
+                target: "overhaul.attach",
+                session_id = %session_id,
+                addr = %addr,
+                attach_id,
+                runtime = %runtime,
+                protocol = overhaul_flags.attach_protocol.as_str(),
+                use_attach_v2,
+                last_seen_seq = ?last_seen_seq,
+                "Attach sequence started"
+            );
+            let clear_mode = if mobile_in_alt_screen {
+                "alternate_screen"
+            } else {
+                "main_screen"
+            };
+            let mut replay_events: Vec<(&'static str, usize)> = Vec::new();
+            if use_attach_v2 {
+                let begin = ServerMessage::AttachBegin {
+                    session_id: session_id.clone(),
+                    attach_id,
+                    runtime: runtime.clone(),
+                    mode: if last_seen_seq.is_some() {
+                        "reconnect".to_string()
+                    } else {
+                        "fresh".to_string()
+                    },
+                    in_alt_screen: mobile_in_alt_screen,
+                };
+                if let Ok(text) = serde_json::to_string(&begin) {
+                    let _ = tx.send(Message::Text(text)).await;
+                }
+            }
 
             // ── Step 1: wipe mobile's xterm.js buffer ──────────────────
             //
@@ -1528,24 +1657,42 @@ async fn process_client_msg(
             // replay starts from a deterministic baseline.
             //
             {
-                let clear: &[u8] = if mobile_in_alt_screen {
-                    // \x1b[?1049h  enter alternate screen
-                    // \x1b[2J      erase display
-                    // \x1b[H       cursor home
-                    b"\x1b[?1049h\x1b[2J\x1b[H"
+                if use_attach_v2 {
+                    let clear = ServerMessage::AttachClear {
+                        session_id: session_id.clone(),
+                        attach_id,
+                    };
+                    if let Ok(text) = serde_json::to_string(&clear) {
+                        let _ = tx.send(Message::Text(text)).await;
+                    }
                 } else {
-                    // \x1b[2J      erase display
-                    // \x1b[3J      erase scrollback (xterm extension, supported by xterm.js)
-                    // \x1b[H       cursor home
-                    b"\x1b[2J\x1b[3J\x1b[H"
-                };
-                let clear_msg = ServerMessage::PtyBytes {
-                    session_id: session_id.clone(),
-                    data: BASE64.encode(clear),
-                };
-                if let Ok(text) = serde_json::to_string(&clear_msg) {
-                    let _ = tx.send(Message::Text(text)).await;
+                    let clear: &[u8] = if mobile_in_alt_screen {
+                        // \x1b[?1049h  enter alternate screen
+                        // \x1b[2J      erase display
+                        // \x1b[H       cursor home
+                        b"\x1b[?1049h\x1b[2J\x1b[H"
+                    } else {
+                        // \x1b[2J      erase display
+                        // \x1b[3J      erase scrollback (xterm extension, supported by xterm.js)
+                        // \x1b[H       cursor home
+                        b"\x1b[2J\x1b[3J\x1b[H"
+                    };
+                    let clear_msg = ServerMessage::PtyBytes {
+                        session_id: session_id.clone(),
+                        data: BASE64.encode(clear),
+                    };
+                    if let Ok(text) = serde_json::to_string(&clear_msg) {
+                        let _ = tx.send(Message::Text(text)).await;
+                    }
                 }
+                tracing::info!(
+                    target: "overhaul.attach",
+                    session_id = %session_id,
+                    attach_id,
+                    clear_mode,
+                    clear_bytes = if use_attach_v2 { 0 } else if mobile_in_alt_screen { b"\x1b[?1049h\x1b[2J\x1b[H".len() } else { b"\x1b[2J\x1b[3J\x1b[H".len() },
+                    "Attach clear frame sent"
+                );
             }
 
             // ── Step 2: replay history ────────────────────────────────────
@@ -1553,18 +1700,59 @@ async fn process_client_msg(
             // PTY text sessions replay daemon scrollback.
             if !render_as_tui {
                 if let Some(bytes) = scrollback_bytes {
-                    let msg = ServerMessage::PtyBytes {
-                        session_id: session_id.clone(),
-                        data: BASE64.encode(&bytes),
-                    };
-                    if let Ok(text) = serde_json::to_string(&msg) {
-                        let _ = tx.send(Message::Text(text)).await;
+                    replay_events.push(("daemon_scrollback", bytes.len()));
+                    if use_attach_v2 {
+                        let chunks = chunk_snapshot_payload(&bytes);
+                        let total_chunks = chunks.len().max(1) as u32;
+                        if chunks.is_empty() {
+                            let msg = ServerMessage::AttachSnapshotChunk {
+                                session_id: session_id.clone(),
+                                attach_id,
+                                chunk_seq: 1,
+                                total_chunks,
+                                is_last: true,
+                                data: String::new(),
+                            };
+                            if let Ok(text) = serde_json::to_string(&msg) {
+                                let _ = tx.send(Message::Text(text)).await;
+                            }
+                        } else {
+                            for (idx, chunk) in chunks.into_iter().enumerate() {
+                                let msg = ServerMessage::AttachSnapshotChunk {
+                                    session_id: session_id.clone(),
+                                    attach_id,
+                                    chunk_seq: (idx + 1) as u32,
+                                    total_chunks,
+                                    is_last: idx + 1 == total_chunks as usize,
+                                    data: chunk,
+                                };
+                                if let Ok(text) = serde_json::to_string(&msg) {
+                                    let _ = tx.send(Message::Text(text)).await;
+                                }
+                            }
+                        }
+                    } else {
+                        let msg = ServerMessage::PtyBytes {
+                            session_id: session_id.clone(),
+                            data: BASE64.encode(&bytes),
+                        };
+                        if let Ok(text) = serde_json::to_string(&msg) {
+                            let _ = tx.send(Message::Text(text)).await;
+                        }
                     }
+                    tracing::info!(
+                        target: "overhaul.attach",
+                        session_id = %session_id,
+                        attach_id,
+                        replay_source = "daemon_scrollback",
+                        replay_bytes = bytes.len(),
+                        "Attach replay sent"
+                    );
                 }
             }
 
             // tmux sessions always get an authoritative pane snapshot on
-            // subscribe. Frame-rendered CLIs request visible pane only.
+            // subscribe.
             if let Some((socket, name, max_bytes, include_scrollback)) = tmux_snapshot_req {
                 let max_lines = if include_scrollback {
                     SUBSCRIBE_SCROLLBACK_LINES
@@ -1578,41 +1766,105 @@ async fn process_client_msg(
                     let total_bytes = snapshot.len();
                     let skip = total_bytes.saturating_sub(max_bytes);
                     let bytes = &snapshot[skip..];
-                    let msg = ServerMessage::SessionHistory {
-                        session_id: session_id.clone(),
-                        data: BASE64.encode(bytes),
-                        total_bytes,
-                    };
-                    if let Ok(text) = serde_json::to_string(&msg) {
-                        let _ = tx.send(Message::Text(text)).await;
+                    replay_events.push(("tmux_capture_pane", bytes.len()));
+                    if use_attach_v2 {
+                        let chunks = chunk_snapshot_payload(bytes);
+                        let total_chunks = chunks.len().max(1) as u32;
+                        if chunks.is_empty() {
+                            let msg = ServerMessage::AttachSnapshotChunk {
+                                session_id: session_id.clone(),
+                                attach_id,
+                                chunk_seq: 1,
+                                total_chunks,
+                                is_last: true,
+                                data: String::new(),
+                            };
+                            if let Ok(text) = serde_json::to_string(&msg) {
+                                let _ = tx.send(Message::Text(text)).await;
+                            }
+                        } else {
+                            for (idx, chunk) in chunks.into_iter().enumerate() {
+                                let msg = ServerMessage::AttachSnapshotChunk {
+                                    session_id: session_id.clone(),
+                                    attach_id,
+                                    chunk_seq: (idx + 1) as u32,
+                                    total_chunks,
+                                    is_last: idx + 1 == total_chunks as usize,
+                                    data: chunk,
+                                };
+                                if let Ok(text) = serde_json::to_string(&msg) {
+                                    let _ = tx.send(Message::Text(text)).await;
+                                }
+                            }
+                        }
+                    } else {
+                        let msg = ServerMessage::SessionHistory {
+                            session_id: session_id.clone(),
+                            data: BASE64.encode(bytes),
+                            total_bytes,
+                        };
+                        if let Ok(text) = serde_json::to_string(&msg) {
+                            let _ = tx.send(Message::Text(text)).await;
+                        }
                     }
-                } else if let Some(fallback) = tmux_fallback_bytes {
-                    tracing::debug!(
+                    tracing::info!(
+                        target: "overhaul.attach",
                         session_id = %session_id,
-                        fallback_bytes = fallback.len(),
-                        "capture-pane failed; using daemon scrollback fallback"
+                        attach_id,
+                        replay_source = "tmux_capture_pane",
+                        replay_bytes = bytes.len(),
+                        total_snapshot_bytes = total_bytes,
+                        "Attach replay sent"
                     );
-                    let total_bytes = fallback.len();
-                    let msg = ServerMessage::SessionHistory {
-                        session_id: session_id.clone(),
-                        data: BASE64.encode(&fallback),
-                        total_bytes,
-                    };
-                    if let Ok(text) = serde_json::to_string(&msg) {
-                        let _ = tx.send(Message::Text(text)).await;
-                    }
+                } else {
+                    tracing::warn!(
+                        target: "overhaul.attach",
+                        session_id = %session_id,
+                        attach_id,
+                        include_scrollback,
+                        "tmux capture-pane unavailable during attach replay"
+                    );
                 }
             }
 
             // Always send SubscribeAck so mobile knows whether to suppress
-            // stale bytes and enter alt-screen mode before resizing.
-            let ack = ServerMessage::SubscribeAck {
-                session_id: session_id.clone(),
-                in_alt_screen: mobile_in_alt_screen,
-                runtime: Some(runtime),
-            };
-            if let Ok(text) = serde_json::to_string(&ack) {
-                let _ = tx.send(Message::Text(text)).await;
+            // stale bytes and enter alt-screen mode before resizing (v1 path).
+            let runtime_for_log = runtime.clone();
+            if use_attach_v2 {
+                let ready_live_seq = {
+                    let st = state.read().await;
+                    st.sessions
+                        .get(&session_id)
+                        .map(|session| session.live_seq)
+                        .unwrap_or(initial_live_seq)
+                };
+                tracing::debug!(
+                    target: "overhaul.sequence",
+                    session_id = %session_id,
+                    attach_id,
+                    initial_live_seq,
+                    ready_live_seq,
+                    "Attach ready sequence barrier"
+                );
+                let ready = ServerMessage::AttachReady {
+                    session_id: session_id.clone(),
+                    attach_id,
+                    last_live_seq: ready_live_seq,
+                    cols: ready_cols,
+                    rows: ready_rows,
+                };
+                if let Ok(text) = serde_json::to_string(&ready) {
+                    let _ = tx.send(Message::Text(text)).await;
+                }
+            } else {
+                let ack = ServerMessage::SubscribeAck {
+                    session_id: session_id.clone(),
+                    in_alt_screen: mobile_in_alt_screen,
+                    runtime: Some(runtime),
+                };
+                if let Ok(text) = serde_json::to_string(&ack) {
+                    let _ = tx.send(Message::Text(text)).await;
+                }
             }
 
             // Register active view after initial clear/replay/ack sequence so
@@ -1620,20 +1872,63 @@ async fn process_client_msg(
             let mut st = state.write().await;
             let entry = st.mobile_views.entry(addr).or_default();
             if entry.insert(session_id.clone()) {
-                let count = st.session_view_counts.entry(session_id).or_insert(0);
+                let count = st
+                    .session_view_counts
+                    .entry(session_id.clone())
+                    .or_insert(0);
                 *count += 1;
             }
+            if use_attach_v2 {
+                st.mobile_attach_ids
+                    .entry(addr)
+                    .or_default()
+                    .insert(session_id.clone(), attach_id);
+            } else {
+                let mut remove_addr = false;
+                if let Some(attach_by_session) = st.mobile_attach_ids.get_mut(&addr) {
+                    attach_by_session.remove(&session_id);
+                    remove_addr = attach_by_session.is_empty();
+                }
+                if remove_addr {
+                    st.mobile_attach_ids.remove(&addr);
+                }
+            }
+            let replay_sources = if replay_events.is_empty() {
+                "none".to_string()
+            } else {
+                replay_events
+                    .iter()
+                    .map(|(source, _)| *source)
+                    .collect::<Vec<_>>()
+                    .join(",")
+            };
+            let replay_bytes_total: usize = replay_events.iter().map(|(_, bytes)| *bytes).sum();
+            tracing::info!(
+                target: "overhaul.attach",
+                session_id = %session_id,
+                addr = %addr,
+                attach_id,
+                runtime = %runtime_for_log,
+                protocol = overhaul_flags.attach_protocol.as_str(),
+                use_attach_v2,
+                clear_mode,
+                replay_sources = %replay_sources,
+                replay_events = replay_events.len(),
+                replay_bytes_total,
+                duration_ms = attach_started.elapsed().as_millis() as u64,
+                "Attach sequence completed"
+            );
         }
         ClientMessage::Unsubscribe { session_id } => {
             tracing::debug!("Client unsubscribed from session: {}", session_id);
             let mut st = state.write().await;
-            let mut remove_entry = false;
-            if let Some(pending) = st.pending_tui_replay.get_mut(&addr) {
-                pending.remove(&session_id);
-                remove_entry = pending.is_empty();
+            let mut remove_attach_addr = false;
+            if let Some(attach_by_session) = st.mobile_attach_ids.get_mut(&addr) {
+                attach_by_session.remove(&session_id);
+                remove_attach_addr = attach_by_session.is_empty();
             }
-            if remove_entry {
-                st.pending_tui_replay.remove(&addr);
+            if remove_attach_addr {
+                st.mobile_attach_ids.remove(&addr);
             }
             if let Some(entry) = st.mobile_views.get_mut(&addr) {
                 if entry.remove(&session_id) {
@@ -1692,6 +1987,7 @@ async fn process_client_msg(
         } => {
             let reason = resolve_resize_reason(cols, rows, reason);
             let mut st = state.write().await;
+            let resize_simplified = st.overhaul_flags.resize_simplified;
             let is_restore = reason == PtyResizeReason::DetachRestore;
             let viewer_count = st
                 .session_view_counts
@@ -1709,6 +2005,7 @@ async fn process_client_msg(
                 should_ignore_resize_without_viewers(is_restore, viewer_count, reason);
             if ignore_no_viewer_resize {
                 tracing::debug!(
+                    target: "overhaul.resize",
                     session_id = %session_id,
                     cols,
                     rows,
@@ -1716,6 +2013,7 @@ async fn process_client_msg(
                     reason = reason.as_str(),
                     viewer_count,
                     sender_is_viewing,
+                    resize_simplified,
                     bootstrap_reason = matches!(reason, PtyResizeReason::AttachInit | PtyResizeReason::ReconnectSync),
                     decision = "ignored_no_active_viewers",
                     "Ignoring PTY resize with no active mobile viewers"
@@ -1727,6 +2025,7 @@ async fn process_client_msg(
             // other viewers are still attached to this session.
             if should_ignore_restore_resize(is_restore, viewer_count, sender_is_viewing) {
                 tracing::debug!(
+                    target: "overhaul.resize",
                     session_id = %session_id,
                     cols,
                     rows,
@@ -1734,6 +2033,7 @@ async fn process_client_msg(
                     reason = reason.as_str(),
                     viewer_count,
                     sender_is_viewing,
+                    resize_simplified,
                     decision = "ignored_restore_guard",
                     "Ignoring PTY restore while active viewers remain"
                 );
@@ -1743,6 +2043,7 @@ async fn process_client_msg(
             if let Some(session) = st.sessions.get_mut(&session_id) {
                 if is_stale_resize_epoch(session.last_resize_epoch, epoch) {
                     tracing::debug!(
+                        target: "overhaul.resize",
                         session_id = %session_id,
                         cols,
                         rows,
@@ -1752,6 +2053,7 @@ async fn process_client_msg(
                         sender_is_viewing,
                         alt_screen = session.in_alt_screen,
                         last_epoch = session.last_resize_epoch,
+                        resize_simplified,
                         decision = "ignored_stale_epoch",
                         "Ignoring stale PTY resize"
                     );
@@ -1764,6 +2066,7 @@ async fn process_client_msg(
                 let ack_dims = session.last_applied_size.unwrap_or((cols, rows));
                 if reason == PtyResizeReason::KeyboardOverlay {
                     tracing::debug!(
+                        target: "overhaul.resize",
                         session_id = %session_id,
                         cols,
                         rows,
@@ -1772,47 +2075,14 @@ async fn process_client_msg(
                         viewer_count,
                         sender_is_viewing,
                         alt_screen = session.in_alt_screen,
+                        resize_simplified,
                         decision = "ignored_keyboard_overlay",
                         "Ignoring keyboard-overlay resize (local UX only)"
                     );
                     synthetic_ack = Some((ack_dims.0, ack_dims.1, epoch));
                 } else if is_noop_resize(session.last_applied_size, cols, rows) {
-                    if should_force_noop_resize(reason) {
-                        tracing::debug!(
-                            session_id = %session_id,
-                            cols,
-                            rows,
-                            epoch = ?epoch,
-                            reason = reason.as_str(),
-                            viewer_count,
-                            sender_is_viewing,
-                            alt_screen = session.in_alt_screen,
-                            decision = "forwarded_noop_refresh",
-                            "Forwarding no-op PTY resize to force redraw"
-                        );
-                        let _ = session.resize_tx.send(ResizeRequest {
-                            cols,
-                            rows,
-                            epoch,
-                            reason,
-                        });
-                    } else {
-                        tracing::debug!(
-                            session_id = %session_id,
-                            cols,
-                            rows,
-                            epoch = ?epoch,
-                            reason = reason.as_str(),
-                            viewer_count,
-                            sender_is_viewing,
-                            alt_screen = session.in_alt_screen,
-                            decision = "ignored_noop",
-                            "Ignoring no-op PTY resize"
-                        );
-                        synthetic_ack = Some((ack_dims.0, ack_dims.1, epoch));
-                    }
-                } else {
                     tracing::debug!(
+                        target: "overhaul.resize",
                         session_id = %session_id,
                         cols,
                         rows,
@@ -1821,6 +2091,23 @@ async fn process_client_msg(
                         viewer_count,
                         sender_is_viewing,
                         alt_screen = session.in_alt_screen,
+                        resize_simplified,
+                        decision = "ignored_noop",
+                        "Ignoring no-op PTY resize"
+                    );
+                    synthetic_ack = Some((ack_dims.0, ack_dims.1, epoch));
+                } else {
+                    tracing::debug!(
+                        target: "overhaul.resize",
+                        session_id = %session_id,
+                        cols,
+                        rows,
+                        epoch = ?epoch,
+                        reason = reason.as_str(),
+                        viewer_count,
+                        sender_is_viewing,
+                        alt_screen = session.in_alt_screen,
+                        resize_simplified,
                         decision = "forwarded",
                         "Forwarding PTY resize to wrapper"
                     );
@@ -1891,7 +2178,7 @@ async fn process_client_msg(
                     drop(session);
                     // Clean up view counts for this session
                     st.session_view_counts.remove(&session_id);
-                    clear_pending_tui_replay_for_session(&mut st, &session_id);
+                    clear_mobile_attach_for_session(&mut st, &session_id);
                     for views in st.mobile_views.values_mut() {
                         views.remove(&session_id);
                     }
@@ -2006,22 +2293,17 @@ async fn process_client_msg(
                 let st = state.read().await;
                 if let Some(session) = st.sessions.get(&session_id) {
                     let max = max_bytes.unwrap_or(session.scrollback_max_bytes);
-                    let render_as_tui = should_treat_as_tui_for_mobile(
-                        &session.runtime,
-                        session.in_alt_screen,
-                        session.frame_render_mode,
-                    );
+                    let render_as_tui =
+                        should_treat_as_tui_for_mobile(&session.runtime, session.in_alt_screen);
                     if session.runtime == "tmux" {
                         if let (Some(socket), Some(name)) =
                             (session.tmux_socket.clone(), session.tmux_session.clone())
                         {
                             tmux_capture_req = Some((socket, name, max, !render_as_tui));
                         }
-                        tail_scrollback_bytes(session, max)
+                        (Vec::new(), 0)
                     } else if render_as_tui {
-                        // PTY frame-rendering sessions can only safely replay
-                        // their live stream; historical replay is often malformed
-                        // after geometry changes.
+                        // PTY alternate-screen sessions are live-only.
                         (Vec::new(), 0)
                     } else {
                         tail_scrollback_bytes(session, max)
@@ -2031,39 +2313,37 @@ async fn process_client_msg(
                 }
             };
 
-            let (data, total_bytes) = if let Some((socket, name, max, include_scrollback)) =
-                tmux_capture_req
-            {
-                // On-demand history requests use the full depth so users can
-                // retrieve the maximum available scrollback from tmux.
-                let max_lines = if include_scrollback {
-                    HISTORY_SCROLLBACK_LINES
-                } else {
-                    0
-                };
-                if let Some(snapshot) =
-                    capture_tmux_history_with_retry(socket, name, include_scrollback, max_lines)
-                        .await
-                {
-                    let total = snapshot.len();
-                    let skip = total.saturating_sub(max);
-                    (BASE64.encode(&snapshot[skip..]), total)
+            let (data, total_bytes) =
+                if let Some((socket, name, max, include_scrollback)) = tmux_capture_req {
+                    // On-demand history requests use the full depth so users can
+                    // retrieve the maximum available scrollback from tmux.
+                    let max_lines = if include_scrollback {
+                        HISTORY_SCROLLBACK_LINES
+                    } else {
+                        0
+                    };
+                    if let Some(snapshot) =
+                        capture_tmux_history_with_retry(socket, name, include_scrollback, max_lines)
+                            .await
+                    {
+                        let total = snapshot.len();
+                        let skip = total.saturating_sub(max);
+                        (BASE64.encode(&snapshot[skip..]), total)
+                    } else {
+                        tracing::warn!(
+                            session_id = %session_id,
+                            "tmux capture-pane unavailable for session_history request"
+                        );
+                        (String::new(), 0)
+                    }
                 } else {
                     tracing::debug!(
                         session_id = %session_id,
                         fallback_total_bytes = fallback_total_bytes,
-                        "tmux capture-pane unavailable, falling back to daemon scrollback replay"
+                        "Using daemon scrollback replay for session_history"
                     );
                     (BASE64.encode(&fallback_bytes), fallback_total_bytes)
-                }
-            } else {
-                tracing::debug!(
-                    session_id = %session_id,
-                    fallback_total_bytes = fallback_total_bytes,
-                    "Using daemon scrollback replay for session_history"
-                );
-                (BASE64.encode(&fallback_bytes), fallback_total_bytes)
-            };
+                };
 
             let msg = ServerMessage::SessionHistory {
                 session_id,
@@ -3009,91 +3289,31 @@ async fn broadcast_pty_resized(
         return;
     };
 
-    let mut ack_clients: Vec<mpsc::Sender<Message>> = Vec::new();
-    let mut replay_clients: Vec<mpsc::Sender<Message>> = Vec::new();
-    let mut replay_payload: Option<String> = None;
-    let mut replay_scrollback_len = 0usize;
-
-    {
-        let mut st = state.write().await;
-        let viewing_addrs: Vec<SocketAddr> = st
-            .mobile_views
+    let ack_clients: Vec<mpsc::Sender<Message>> = {
+        let st = state.read().await;
+        st.mobile_views
             .iter()
-            .filter_map(|(addr, views)| views.contains(session_id).then_some(*addr))
-            .collect();
-
-        if !viewing_addrs.is_empty() {
-            for addr in &viewing_addrs {
-                if let Some(client) = st.mobile_clients.get(addr) {
-                    ack_clients.push(client.clone());
+            .filter_map(|(addr, views)| {
+                if !views.contains(session_id) {
+                    return None;
                 }
-            }
-
-            let replay_addrs: Vec<SocketAddr> = viewing_addrs
-                .iter()
-                .copied()
-                .filter(|addr| {
-                    st.pending_tui_replay
-                        .get(addr)
-                        .map(|pending| pending.contains(session_id))
-                        .unwrap_or(false)
-                })
-                .collect();
-
-            if !replay_addrs.is_empty() {
-                if let Some(session) = st.sessions.get(session_id) {
-                    if session.runtime != "tmux" && !session.scrollback.is_empty() {
-                        replay_scrollback_len = session.scrollback.len();
-                        let bytes: Vec<u8> = session.scrollback.iter().copied().collect();
-                        let replay_msg = ServerMessage::PtyBytes {
-                            session_id: session_id.to_string(),
-                            data: BASE64.encode(&bytes),
-                        };
-                        replay_payload = serde_json::to_string(&replay_msg).ok();
-                    } else if session.runtime == "tmux" {
-                        tracing::debug!(
-                            session_id = %session_id,
-                            "Skipping deferred raw replay for tmux runtime; mobile will request capture-pane snapshot"
-                        );
-                    }
-                }
-
-                for addr in replay_addrs {
-                    if let Some(client) = st.mobile_clients.get(&addr) {
-                        replay_clients.push(client.clone());
-                    }
-                    let mut remove_entry = false;
-                    if let Some(pending) = st.pending_tui_replay.get_mut(&addr) {
-                        pending.remove(session_id);
-                        remove_entry = pending.is_empty();
-                    }
-                    if remove_entry {
-                        st.pending_tui_replay.remove(&addr);
-                    }
-                }
-            }
-        }
-    }
+                st.mobile_clients.get(addr).cloned()
+            })
+            .collect()
+    };
 
     tracing::debug!(
+        target: "overhaul.resize",
         session_id = %session_id,
         cols,
         rows,
         epoch = ?epoch,
         ack_clients = ack_clients.len(),
-        replay_clients = replay_clients.len(),
-        replay_scrollback_len,
-        replay_payload_len = replay_payload.as_ref().map(|s| s.len()).unwrap_or(0),
         "Broadcasted pty_resized"
     );
 
     for client in ack_clients {
         let _ = client.try_send(Message::Text(msg_str.clone()));
-    }
-    if let Some(payload) = replay_payload {
-        for client in replay_clients {
-            let _ = client.try_send(Message::Text(payload.clone()));
-        }
     }
 }
 
@@ -3158,6 +3378,36 @@ fn tail_scrollback_bytes(session: &PtySession, max_bytes: usize) -> (Vec<u8>, us
     let skip = total.saturating_sub(max_bytes);
     let bytes: Vec<u8> = session.scrollback.iter().skip(skip).copied().collect();
     (bytes, total)
+}
+
+fn client_supports_attach_v2(capabilities: u32) -> bool {
+    capabilities & CLIENT_CAP_ATTACH_V2 != 0
+}
+
+fn should_use_attach_v2(flags: OverhaulFlags, capabilities: u32) -> bool {
+    flags.attach_protocol == AttachProtocolMode::V2 && client_supports_attach_v2(capabilities)
+}
+
+fn chunk_snapshot_payload(data: &[u8]) -> Vec<String> {
+    if data.is_empty() {
+        return Vec::new();
+    }
+    data.chunks(SNAPSHOT_CHUNK_BYTES)
+        .map(|chunk| BASE64.encode(chunk))
+        .collect()
+}
+
+fn clear_mobile_attach_for_session(st: &mut DaemonState, session_id: &str) {
+    let mut remove_addrs = Vec::new();
+    for (addr, attach_by_session) in st.mobile_attach_ids.iter_mut() {
+        attach_by_session.remove(session_id);
+        if attach_by_session.is_empty() {
+            remove_addrs.push(*addr);
+        }
+    }
+    for addr in remove_addrs {
+        st.mobile_attach_ids.remove(&addr);
+    }
 }
 
 fn capture_tmux_history_blocking(
@@ -3362,13 +3612,6 @@ fn is_noop_resize(last_applied: Option<(u16, u16)>, cols: u16, rows: u16) -> boo
     last_applied == Some((cols, rows))
 }
 
-fn should_force_noop_resize(reason: PtyResizeReason) -> bool {
-    matches!(
-        reason,
-        PtyResizeReason::AttachInit | PtyResizeReason::ReconnectSync
-    )
-}
-
 fn should_ignore_resize_without_viewers(
     is_restore: bool,
     viewer_count: usize,
@@ -3384,35 +3627,23 @@ fn should_ignore_resize_without_viewers(
     )
 }
 
-fn should_treat_as_tui_for_mobile(
-    runtime: &str,
-    in_alt_screen: bool,
-    frame_render_mode: bool,
-) -> bool {
+fn should_treat_as_tui_for_mobile(runtime: &str, in_alt_screen: bool) -> bool {
+    // tmux runtime intentionally keeps alternate-screen disabled so pane
+    // snapshots remain canonical and replay-safe.
     if runtime == "tmux" {
-        // tmux runtime keeps alternate-screen disabled at bootstrap, so use
-        // frame-render mode as the TUI gate.
-        return frame_render_mode;
+        return false;
     }
-    in_alt_screen || frame_render_mode
+    in_alt_screen
 }
 
-fn should_mobile_enter_alt_screen(
-    runtime: &str,
-    in_alt_screen: bool,
-    frame_render_mode: bool,
-) -> bool {
+fn should_mobile_enter_alt_screen(runtime: &str, in_alt_screen: bool) -> bool {
     // tmux runtime intentionally disables alternate-screen at the host level.
     // Ignore raw 1049/1047 bytes from pane output and keep mobile in main
     // buffer for deterministic replay + scrollback behavior.
     if runtime == "tmux" {
         return false;
     }
-    // Preserve real alternate-screen behavior for non-tmux runtimes.
-    if in_alt_screen {
-        return true;
-    }
-    frame_render_mode
+    in_alt_screen
 }
 
 fn is_stale_resize_epoch(last_epoch: u64, incoming_epoch: Option<u64>) -> bool {
@@ -3444,79 +3675,6 @@ fn update_alt_screen_state(in_alt_screen: &mut bool, tail: &mut Vec<u8>, chunk: 
     let keep = ALT_TRACK_TAIL_BYTES.min(scan.len());
     tail.clear();
     tail.extend_from_slice(&scan[scan.len() - keep..]);
-}
-
-fn cli_defaults_to_frame_mode(cli: CliType) -> bool {
-    // Pre-set frame mode for known full-screen TUI apps so the very first
-    // mobile subscribe (before the output heuristic has seen enough frames)
-    // skips the desktop-width capture-pane and enters alt-screen immediately.
-    // The heuristic still runs and will detect any other frame-rendering app.
-    matches!(
-        cli,
-        CliType::Codex | CliType::OpenCode | CliType::Claude | CliType::Gemini
-    )
-}
-
-fn should_enable_frame_mode(cursor_ops: u32, erase_ops: u32) -> bool {
-    cursor_ops >= FRAME_CURSOR_THRESHOLD && erase_ops >= FRAME_ERASE_THRESHOLD
-}
-
-fn scan_frame_sequences(chunk: &[u8]) -> (u32, u32) {
-    let mut cursor_ops = 0u32;
-    let mut erase_ops = 0u32;
-    let mut i = 0usize;
-
-    while i + 2 < chunk.len() {
-        if chunk[i] != 0x1b || chunk[i + 1] != b'[' {
-            i += 1;
-            continue;
-        }
-
-        let mut j = i + 2;
-        while j < chunk.len() && (chunk[j].is_ascii_digit() || chunk[j] == b';' || chunk[j] == b'?')
-        {
-            j += 1;
-        }
-
-        if j >= chunk.len() {
-            break;
-        }
-
-        let final_byte = chunk[j];
-        let params = &chunk[i + 2..j];
-
-        if final_byte == b'H' && (params.is_empty() || params.contains(&b';')) {
-            cursor_ops += 1;
-        } else if final_byte == b'K' {
-            erase_ops += 1;
-        }
-
-        i = j + 1;
-    }
-
-    (cursor_ops, erase_ops)
-}
-
-fn update_frame_render_state(
-    frame_mode: &mut bool,
-    cursor_ops: &mut u32,
-    erase_ops: &mut u32,
-    chunk: &[u8],
-) {
-    if *frame_mode || chunk.is_empty() {
-        return;
-    }
-
-    let (cursor_inc, erase_inc) = scan_frame_sequences(chunk);
-    if cursor_inc == 0 && erase_inc == 0 {
-        return;
-    }
-
-    *cursor_ops = cursor_ops.saturating_add(cursor_inc);
-    *erase_ops = erase_ops.saturating_add(erase_inc);
-    if should_enable_frame_mode(*cursor_ops, *erase_ops) {
-        *frame_mode = true;
-    }
 }
 
 fn build_notification_text(
@@ -3566,7 +3724,8 @@ async fn cleanup_client_state(state: &SharedState, addr: SocketAddr) {
         for sender_id in stale_sender_ids {
             st.mobile_sender_addrs.remove(&sender_id);
         }
-        st.pending_tui_replay.remove(&addr);
+        st.mobile_client_capabilities.remove(&addr);
+        st.mobile_attach_ids.remove(&addr);
 
         let sessions_to_restore = match st.mobile_views.remove(&addr) {
             Some(sessions) => {
@@ -3645,19 +3804,6 @@ fn is_path_watched(changed_path: &str, watched: &std::collections::HashSet<Strin
     false
 }
 
-fn clear_pending_tui_replay_for_session(st: &mut DaemonState, session_id: &str) {
-    let mut empty_addrs = Vec::new();
-    for (addr, pending) in st.pending_tui_replay.iter_mut() {
-        pending.remove(session_id);
-        if pending.is_empty() {
-            empty_addrs.push(*addr);
-        }
-    }
-    for addr in empty_addrs {
-        st.pending_tui_replay.remove(&addr);
-    }
-}
-
 async fn restore_pty_size(state: &SharedState, session_id: &str) {
     let st = state.read().await;
     if let Some(session) = st.sessions.get(session_id) {
@@ -3724,20 +3870,15 @@ async fn send_push_notifications(tokens: &[PushToken], title: &str, body: &str, 
 #[cfg(test)]
 mod tests {
     use super::{
-        broadcast_pty_resized, build_upload_destination_path, capture_tmux_history, is_noop_resize,
-        is_stale_resize_epoch, is_windows_reserved_device_name, resolve_resize_reason,
-        sanitize_upload_file_name, scan_frame_sequences, should_enable_frame_mode,
-        should_force_noop_resize, should_ignore_resize_without_viewers,
-        should_ignore_restore_resize, should_mobile_enter_alt_screen,
-        should_treat_as_tui_for_mobile, strip_terminal_report_sequences,
-        strip_terminal_report_sequences_stateful, update_alt_screen_state,
-        update_frame_render_state, DaemonState, PtyResizeReason, PtySession,
-        DEFAULT_SCROLLBACK_MAX_BYTES, MAX_UPLOAD_FILE_NAME_BYTES,
+        broadcast_pty_resized, build_upload_destination_path, capture_tmux_history,
+        clear_mobile_attach_for_session, is_noop_resize, is_stale_resize_epoch,
+        is_windows_reserved_device_name, resolve_resize_reason, sanitize_upload_file_name,
+        should_ignore_resize_without_viewers, should_ignore_restore_resize,
+        should_mobile_enter_alt_screen, should_treat_as_tui_for_mobile, should_use_attach_v2,
+        strip_terminal_report_sequences, strip_terminal_report_sequences_stateful,
+        update_alt_screen_state, AttachProtocolMode, DaemonState, OverhaulFlags, PtyResizeReason,
+        CLIENT_CAP_ATTACH_V2, DEFAULT_SCROLLBACK_MAX_BYTES, MAX_UPLOAD_FILE_NAME_BYTES,
     };
-    use crate::detection::{CliTracker, CliType};
-    use base64::Engine as _;
-    use chrono::Utc;
-    use std::collections::VecDeque;
     use std::sync::Arc;
     use tempfile::TempDir;
     use tokio::sync::{mpsc, RwLock};
@@ -3989,16 +4130,6 @@ mod tests {
     }
 
     #[test]
-    fn force_noop_resize_only_for_attach_and_reconnect() {
-        assert!(should_force_noop_resize(PtyResizeReason::AttachInit));
-        assert!(should_force_noop_resize(PtyResizeReason::ReconnectSync));
-        assert!(!should_force_noop_resize(PtyResizeReason::GeometryChange));
-        assert!(!should_force_noop_resize(PtyResizeReason::DetachRestore));
-        assert!(!should_force_noop_resize(PtyResizeReason::KeyboardOverlay));
-        assert!(!should_force_noop_resize(PtyResizeReason::Unknown));
-    }
-
-    #[test]
     fn no_viewer_guard_allows_bootstrap_resizes() {
         assert!(should_ignore_resize_without_viewers(
             false,
@@ -4028,75 +4159,78 @@ mod tests {
     }
 
     #[test]
-    fn tui_gating_uses_frame_render_for_all_runtimes() {
-        // tmux runtime ignores raw alt-screen bytes and relies on frame mode.
-        assert!(should_treat_as_tui_for_mobile("tmux", false, true));
-        assert!(!should_treat_as_tui_for_mobile("tmux", false, false));
-        assert!(!should_treat_as_tui_for_mobile("tmux", true, false));
-        assert!(should_treat_as_tui_for_mobile("pty", false, true));
-        assert!(!should_treat_as_tui_for_mobile("pty", false, false));
+    fn tui_gating_uses_alt_screen_only() {
+        assert!(!should_treat_as_tui_for_mobile("tmux", false));
+        assert!(!should_treat_as_tui_for_mobile("tmux", true));
+        assert!(should_treat_as_tui_for_mobile("pty", true));
+        assert!(!should_treat_as_tui_for_mobile("pty", false));
     }
 
     #[test]
     fn mobile_alt_screen_policy_preserves_tmux_scrollback() {
-        assert!(!should_mobile_enter_alt_screen("tmux", false, true));
-        assert!(!should_mobile_enter_alt_screen("tmux", false, false));
-        assert!(!should_mobile_enter_alt_screen("tmux", true, false));
-        assert!(should_mobile_enter_alt_screen("pty", false, true));
-        assert!(!should_mobile_enter_alt_screen("pty", false, false));
+        assert!(!should_mobile_enter_alt_screen("tmux", false));
+        assert!(!should_mobile_enter_alt_screen("tmux", true));
+        assert!(should_mobile_enter_alt_screen("pty", true));
+        assert!(!should_mobile_enter_alt_screen("pty", false));
     }
 
     #[test]
-    fn frame_sequence_scanner_counts_cursor_and_erase_ops() {
-        let chunk = b"\x1b[10;2HHello\x1b[K\x1b[H\x1b[2K";
-        let (cursor, erase) = scan_frame_sequences(chunk);
-        assert_eq!(cursor, 2);
-        assert_eq!(erase, 2);
+    fn attach_v2_gating_requires_flag_and_capability() {
+        let v1_flags = OverhaulFlags {
+            attach_protocol: AttachProtocolMode::V1,
+            enable_local_echo: false,
+            resize_simplified: false,
+        };
+        let v2_flags = OverhaulFlags {
+            attach_protocol: AttachProtocolMode::V2,
+            enable_local_echo: false,
+            resize_simplified: false,
+        };
+
+        assert!(!should_use_attach_v2(v1_flags, CLIENT_CAP_ATTACH_V2));
+        assert!(!should_use_attach_v2(v2_flags, 0));
+        assert!(should_use_attach_v2(v2_flags, CLIENT_CAP_ATTACH_V2));
     }
 
     #[test]
-    fn frame_mode_threshold_requires_heavy_cursor_and_erase_usage() {
-        assert!(!should_enable_frame_mode(79, 40));
-        assert!(!should_enable_frame_mode(80, 39));
-        assert!(should_enable_frame_mode(80, 40));
-        assert!(should_enable_frame_mode(400, 200));
-    }
+    fn clear_mobile_attach_for_session_prunes_empty_maps() {
+        let mut state = DaemonState::new(9847);
+        let addr_a: std::net::SocketAddr = "127.0.0.1:50001".parse().expect("socket addr a");
+        let addr_b: std::net::SocketAddr = "127.0.0.1:50002".parse().expect("socket addr b");
 
-    #[test]
-    fn frame_mode_update_flips_after_threshold() {
-        let mut frame_mode = false;
-        let mut cursor = 0u32;
-        let mut erase = 0u32;
-        let chunk = b"\x1b[10;2H\x1b[K";
+        state.mobile_attach_ids.insert(
+            addr_a,
+            std::collections::HashMap::from([
+                ("target".to_string(), 1u64),
+                ("keep".to_string(), 2u64),
+            ]),
+        );
+        state.mobile_attach_ids.insert(
+            addr_b,
+            std::collections::HashMap::from([("target".to_string(), 9u64)]),
+        );
 
-        for _ in 0..79 {
-            update_frame_render_state(&mut frame_mode, &mut cursor, &mut erase, chunk);
-        }
-        assert!(!frame_mode);
+        clear_mobile_attach_for_session(&mut state, "target");
 
-        update_frame_render_state(&mut frame_mode, &mut cursor, &mut erase, chunk);
-        assert!(frame_mode);
-    }
-
-    #[test]
-    fn known_tui_apps_preset_frame_mode() {
-        assert!(super::cli_defaults_to_frame_mode(CliType::Codex));
-        assert!(super::cli_defaults_to_frame_mode(CliType::OpenCode));
-        assert!(super::cli_defaults_to_frame_mode(CliType::Claude));
-        assert!(super::cli_defaults_to_frame_mode(CliType::Gemini));
-        assert!(!super::cli_defaults_to_frame_mode(CliType::Terminal));
+        let a_map = state
+            .mobile_attach_ids
+            .get(&addr_a)
+            .expect("addr_a survives");
+        assert!(!a_map.contains_key("target"));
+        assert_eq!(a_map.get("keep"), Some(&2u64));
+        assert!(
+            !state.mobile_attach_ids.contains_key(&addr_b),
+            "addr_b should be pruned when its map becomes empty"
+        );
     }
 
     #[tokio::test]
-    async fn pty_resized_replays_pending_tui_scrollback_only_once() {
+    async fn pty_resized_broadcasts_ack_only() {
         let state = Arc::new(RwLock::new(DaemonState::new(9847)));
         let addr: std::net::SocketAddr = "127.0.0.1:40001".parse().expect("socket addr");
         let session_id = "test-session".to_string();
-        let replay_bytes = b"REPLAY-ME".to_vec();
 
         let (client_tx, mut client_rx) = mpsc::channel::<Message>(32);
-        let (input_tx, _input_rx) = mpsc::unbounded_channel();
-        let (resize_tx, _resize_rx) = mpsc::unbounded_channel();
 
         {
             let mut st = state.write().await;
@@ -4106,51 +4240,12 @@ mod tests {
                 .or_default()
                 .insert(session_id.clone());
             st.session_view_counts.insert(session_id.clone(), 1);
-            st.pending_tui_replay
-                .entry(addr)
-                .or_default()
-                .insert(session_id.clone());
-
-            let mut scrollback = VecDeque::new();
-            scrollback.extend(replay_bytes.iter().copied());
-
-            let mut cli_tracker = CliTracker::new();
-            cli_tracker.update_from_command("codex");
-
-            st.sessions.insert(
-                session_id.clone(),
-                PtySession {
-                    session_id: session_id.clone(),
-                    runtime: "pty".to_string(),
-                    tmux_socket: None,
-                    tmux_session: None,
-                    name: "Codex".to_string(),
-                    command: "codex".to_string(),
-                    project_path: "/tmp".to_string(),
-                    started_at: Utc::now(),
-                    input_tx,
-                    resize_tx,
-                    waiting_state: None,
-                    cli_tracker,
-                    last_wait_hash: None,
-                    scrollback,
-                    scrollback_max_bytes: DEFAULT_SCROLLBACK_MAX_BYTES,
-                    in_alt_screen: false,
-                    alt_track_tail: Vec::new(),
-                    frame_cursor_pos_count: 0,
-                    frame_erase_line_count: 0,
-                    frame_render_mode: true,
-                    last_resize_epoch: 0,
-                    last_applied_size: Some((95, 27)),
-                    raw_input_tail: Vec::new(),
-                },
-            );
         }
 
         broadcast_pty_resized(&state, &session_id, 95, 27, Some(1)).await;
 
         let mut first_ack = 0usize;
-        let mut first_replay = Vec::new();
+        let mut first_replay = 0usize;
         loop {
             match timeout(Duration::from_millis(50), client_rx.recv()).await {
                 Ok(Some(Message::Text(text))) => {
@@ -4158,17 +4253,7 @@ mod tests {
                         serde_json::from_str(text.as_ref()).expect("valid json");
                     match msg.get("type").and_then(|t| t.as_str()) {
                         Some("pty_resized") => first_ack += 1,
-                        Some("pty_bytes") => {
-                            let data = msg
-                                .get("data")
-                                .and_then(|d| d.as_str())
-                                .expect("pty bytes data");
-                            first_replay.push(
-                                base64::engine::general_purpose::STANDARD
-                                    .decode(data)
-                                    .expect("base64 decode"),
-                            );
-                        }
+                        Some("pty_bytes") => first_replay += 1,
                         _ => {}
                     }
                 }
@@ -4178,17 +4263,7 @@ mod tests {
         }
 
         assert_eq!(first_ack, 1);
-        assert_eq!(first_replay.len(), 1);
-        assert_eq!(first_replay[0], replay_bytes);
-
-        {
-            let st = state.read().await;
-            assert!(!st
-                .pending_tui_replay
-                .get(&addr)
-                .map(|pending| pending.contains(&session_id))
-                .unwrap_or(false));
-        }
+        assert_eq!(first_replay, 0);
 
         broadcast_pty_resized(&state, &session_id, 96, 27, Some(2)).await;
 

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -1377,11 +1377,14 @@ async fn process_client_msg(
                 let render_as_tui = session.in_alt_screen || session.frame_render_mode;
                 let has_scrollback = !session.scrollback.is_empty();
                 let runtime = session.runtime.clone();
-                let tmux_snapshot_req = if runtime == "tmux" {
+                let tmux_snapshot_req = if runtime == "tmux" && !render_as_tui {
                     match (&session.tmux_socket, &session.tmux_session) {
-                        (Some(socket), Some(name)) => {
-                            Some((socket.clone(), name.clone(), session.scrollback_max_bytes))
-                        }
+                        (Some(socket), Some(name)) => Some((
+                            socket.clone(),
+                            name.clone(),
+                            session.scrollback_max_bytes,
+                            true,
+                        )),
                         _ => None,
                     }
                 } else {
@@ -1446,8 +1449,9 @@ async fn process_client_msg(
                 }
             }
 
-            if let Some((socket, name, max_bytes)) = tmux_snapshot_req {
-                if let Some(snapshot) = capture_tmux_history(socket, name).await {
+            if let Some((socket, name, max_bytes, include_scrollback)) = tmux_snapshot_req {
+                if let Some(snapshot) = capture_tmux_history(socket, name, include_scrollback).await
+                {
                     let total_bytes = snapshot.len();
                     let skip = total_bytes.saturating_sub(max_bytes);
                     let bytes = &snapshot[skip..];
@@ -1500,11 +1504,32 @@ async fn process_client_msg(
             }
         }
         ClientMessage::SendInput {
-            session_id, text, ..
+            session_id,
+            text,
+            raw,
+            ..
         } => {
             let st = state.read().await;
             if let Some(session) = st.sessions.get(&session_id) {
-                let _ = session.input_tx.send(text.into_bytes());
+                let mut payload = text.into_bytes();
+                if raw {
+                    let (filtered, dropped) = strip_terminal_report_sequences(&payload);
+                    if dropped > 0 {
+                        tracing::debug!(
+                            session_id = %session_id,
+                            runtime = %session.runtime,
+                            dropped_sequences = dropped,
+                            original_len = payload.len(),
+                            filtered_len = filtered.len(),
+                            "Dropped terminal-report reply sequences from mobile raw input"
+                        );
+                    }
+                    payload = filtered;
+                }
+
+                if !payload.is_empty() {
+                    let _ = session.input_tx.send(payload);
+                }
             }
         }
         ClientMessage::PtyResize {
@@ -1822,16 +1847,19 @@ async fn process_client_msg(
             session_id,
             max_bytes,
         } => {
-            let mut tmux_capture_req: Option<(String, String, usize)> = None;
+            let mut tmux_capture_req: Option<(String, String, usize, bool)> = None;
             let (fallback_bytes, fallback_total_bytes) = {
                 let st = state.read().await;
                 if let Some(session) = st.sessions.get(&session_id) {
                     let max = max_bytes.unwrap_or(session.scrollback_max_bytes);
                     if session.runtime == "tmux" {
+                        let render_as_tui = session.in_alt_screen || session.frame_render_mode;
                         if let (Some(socket), Some(name)) =
                             (session.tmux_socket.clone(), session.tmux_session.clone())
                         {
-                            tmux_capture_req = Some((socket, name, max));
+                            // For frame-rendered TUIs use visible pane snapshot only.
+                            // Full scrollback replay here can flood mobile and corrupt redraw.
+                            tmux_capture_req = Some((socket, name, max, !render_as_tui));
                         }
                     }
                     tail_scrollback_bytes(session, max)
@@ -1840,8 +1868,11 @@ async fn process_client_msg(
                 }
             };
 
-            let (data, total_bytes) = if let Some((socket, name, max)) = tmux_capture_req {
-                if let Some(snapshot) = capture_tmux_history(socket, name).await {
+            let (data, total_bytes) = if let Some((socket, name, max, include_scrollback)) =
+                tmux_capture_req
+            {
+                if let Some(snapshot) = capture_tmux_history(socket, name, include_scrollback).await
+                {
                     let total = snapshot.len();
                     let skip = total.saturating_sub(max);
                     (BASE64.encode(&snapshot[skip..]), total)
@@ -2964,27 +2995,31 @@ fn tail_scrollback_bytes(session: &PtySession, max_bytes: usize) -> (Vec<u8>, us
     (bytes, total)
 }
 
-fn capture_tmux_history_blocking(socket: &str, session: &str) -> Option<Vec<u8>> {
+fn capture_tmux_history_blocking(
+    socket: &str,
+    session: &str,
+    include_scrollback: bool,
+) -> Option<Vec<u8>> {
     let targets = [
         format!("{}:0.0", session),
         format!("{}:0", session),
         session.to_string(),
     ];
     for target in targets {
-        let output = std::process::Command::new("tmux")
-            .arg("-L")
+        let mut cmd = std::process::Command::new("tmux");
+        cmd.arg("-L")
             .arg(socket)
             .arg("-f")
             .arg("/dev/null")
             .env_remove("TMUX")
             .arg("capture-pane")
             .arg("-p")
-            .arg("-e")
-            .arg("-S")
-            .arg("-200000")
-            .arg("-t")
-            .arg(&target)
-            .output();
+            .arg("-e");
+        if include_scrollback {
+            cmd.arg("-S").arg("-200000");
+        }
+        cmd.arg("-t").arg(&target);
+        let output = cmd.output();
         if let Ok(out) = output {
             if out.status.success() {
                 return Some(out.stdout);
@@ -2994,11 +3029,76 @@ fn capture_tmux_history_blocking(socket: &str, session: &str) -> Option<Vec<u8>>
     None
 }
 
-async fn capture_tmux_history(socket: String, session: String) -> Option<Vec<u8>> {
-    tokio::task::spawn_blocking(move || capture_tmux_history_blocking(&socket, &session))
-        .await
-        .ok()
-        .flatten()
+async fn capture_tmux_history(
+    socket: String,
+    session: String,
+    include_scrollback: bool,
+) -> Option<Vec<u8>> {
+    tokio::task::spawn_blocking(move || {
+        capture_tmux_history_blocking(&socket, &session, include_scrollback)
+    })
+    .await
+    .ok()
+    .flatten()
+}
+
+fn is_terminal_report_csi(body: &[u8], final_byte: u8) -> bool {
+    match final_byte {
+        // Device Attributes response (e.g. ESC[>0;276;0c from xterm.js)
+        b'c' => body.starts_with(b">") || body.starts_with(b"?"),
+        // Cursor position report (ESC[row;colR)
+        b'R' => body.contains(&b';') && body.iter().all(|b| b.is_ascii_digit() || *b == b';'),
+        // Status reports (ESC[0n / ESC[3n / ESC[?...)
+        b'n' => body.starts_with(b"?") || body.iter().all(|b| b.is_ascii_digit() || *b == b';'),
+        // Mode reports (ESC[?...$y)
+        b'y' => body.starts_with(b"?") && body.contains(&b'$'),
+        _ => false,
+    }
+}
+
+fn strip_terminal_report_sequences(input: &[u8]) -> (Vec<u8>, usize) {
+    let mut out = Vec::with_capacity(input.len());
+    let mut i = 0usize;
+    let mut dropped = 0usize;
+
+    while i < input.len() {
+        if input[i] == 0x1b && i + 2 < input.len() && input[i + 1] == b'[' {
+            let mut j = i + 2;
+            while j < input.len() {
+                let b = input[j];
+                // End of CSI sequence.
+                if b.is_ascii_alphabetic() || b == b'~' {
+                    let body = &input[i + 2..j];
+                    if is_terminal_report_csi(body, b) {
+                        dropped += 1;
+                        i = j + 1;
+                        break;
+                    }
+                    // Not a report sequence; keep original bytes.
+                    out.extend_from_slice(&input[i..=j]);
+                    i = j + 1;
+                    break;
+                }
+                // Malformed / too long sequence; stop scanning to avoid pathological loops.
+                if b == 0x1b || (j - i) > 64 {
+                    out.push(input[i]);
+                    i += 1;
+                    break;
+                }
+                j += 1;
+            }
+            if j >= input.len() {
+                out.push(input[i]);
+                i += 1;
+            }
+            continue;
+        }
+
+        out.push(input[i]);
+        i += 1;
+    }
+
+    (out, dropped)
 }
 
 fn should_ignore_restore_resize(
@@ -3323,9 +3423,9 @@ mod tests {
         broadcast_pty_resized, build_upload_destination_path, capture_tmux_history, is_noop_resize,
         is_stale_resize_epoch, is_windows_reserved_device_name, resolve_resize_reason,
         sanitize_upload_file_name, scan_frame_sequences, should_enable_frame_mode,
-        should_force_noop_resize, should_ignore_restore_resize, update_alt_screen_state,
-        update_frame_render_state, DaemonState, PtyResizeReason, PtySession,
-        DEFAULT_SCROLLBACK_MAX_BYTES, MAX_UPLOAD_FILE_NAME_BYTES,
+        should_force_noop_resize, should_ignore_restore_resize, strip_terminal_report_sequences,
+        update_alt_screen_state, update_frame_render_state, DaemonState, PtyResizeReason,
+        PtySession, DEFAULT_SCROLLBACK_MAX_BYTES, MAX_UPLOAD_FILE_NAME_BYTES,
     };
     use crate::detection::{CliTracker, CliType};
     use base64::Engine as _;
@@ -3341,6 +3441,30 @@ mod tests {
     fn default_scrollback_is_large_enough_for_frame_clis() {
         assert_eq!(DEFAULT_SCROLLBACK_MAX_BYTES, 2 * 1024 * 1024);
         assert!(DEFAULT_SCROLLBACK_MAX_BYTES > 64 * 1024);
+    }
+
+    #[test]
+    fn strip_terminal_reports_drops_secondary_da_reply() {
+        let input = b"\x1b[>0;276;0c";
+        let (out, dropped) = strip_terminal_report_sequences(input);
+        assert_eq!(dropped, 1);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn strip_terminal_reports_preserves_user_escape_keys() {
+        let input = b"abc\x1b[A\r";
+        let (out, dropped) = strip_terminal_report_sequences(input);
+        assert_eq!(dropped, 0);
+        assert_eq!(out, input);
+    }
+
+    #[test]
+    fn strip_terminal_reports_removes_embedded_report_sequences() {
+        let input = b"hello\x1b[>0;276;0cworld";
+        let (out, dropped) = strip_terminal_report_sequences(input);
+        assert_eq!(dropped, 1);
+        assert_eq!(out, b"helloworld");
     }
 
     #[tokio::test]
@@ -3376,7 +3500,7 @@ mod tests {
 
         tokio::time::sleep(Duration::from_millis(150)).await;
 
-        let snapshot = capture_tmux_history(socket.clone(), session.clone())
+        let snapshot = capture_tmux_history(socket.clone(), session.clone(), true)
             .await
             .expect("tmux snapshot");
         let text = String::from_utf8_lossy(&snapshot);

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -4021,15 +4021,16 @@ mod tests {
     }
 
     #[test]
-    fn tmux_mobile_tui_gating_uses_real_alt_screen_only() {
-        // tmux frame-mode sessions that are not in true alt-screen should keep
-        // normal streaming + scrollback replay behavior.
-        assert!(!should_treat_as_tui_for_mobile("tmux", false, true));
+    fn tui_gating_uses_frame_render_for_all_runtimes() {
+        // alternate-screen is disabled in tmux so in_alt_screen is always
+        // false there.  frame_render_mode must trigger TUI treatment for
+        // tmux sessions too, otherwise mobile never enters alt-screen and
+        // every TUI frame pollutes main-buffer scrollback.
+        assert!(should_treat_as_tui_for_mobile("tmux", false, true));
         assert!(!should_treat_as_tui_for_mobile("tmux", false, false));
-        // True alt-screen sessions must still use suppression/reconnect guards.
         assert!(should_treat_as_tui_for_mobile("tmux", true, false));
-        // Legacy PTY runtime preserves historical frame-mode treatment.
         assert!(should_treat_as_tui_for_mobile("pty", false, true));
+        assert!(!should_treat_as_tui_for_mobile("pty", false, false));
     }
 
     #[test]

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -113,13 +113,13 @@ pub struct PushToken {
     pub platform: String, // "ios" | "android"
 }
 
-/// Default scrollback buffer size (2MB).
+/// Default scrollback buffer size (8MB).
 ///
 /// Codex/OpenCode-style frame UIs emit high-volume ANSI redraw traffic. A
 /// 64KB tail can roll over quickly and make reopened sessions appear to have
 /// "lost" earlier chat. Retaining a larger buffer keeps substantially more
 /// recoverable history while still bounding memory.
-const DEFAULT_SCROLLBACK_MAX_BYTES: usize = 2 * 1024 * 1024;
+const DEFAULT_SCROLLBACK_MAX_BYTES: usize = 8 * 1024 * 1024;
 const ALT_ENTER_SEQS: &[&[u8]] = &[b"\x1b[?1049h", b"\x1b[?1047h", b"\x1b[?47h"];
 const ALT_LEAVE_SEQS: &[&[u8]] = &[b"\x1b[?1049l", b"\x1b[?1047l", b"\x1b[?47l"];
 const ALT_TRACK_TAIL_BYTES: usize = 7;
@@ -1373,12 +1373,18 @@ async fn process_client_msg(
             let (
                 scrollback_bytes,
                 render_as_tui,
+                in_alt_screen,
+                frame_render_mode,
                 queue_deferred_replay,
                 scrollback_len,
                 runtime,
                 tmux_snapshot_req,
             ) = if let Some(session) = st.sessions.get(&session_id) {
-                let render_as_tui = session.in_alt_screen || session.frame_render_mode;
+                let render_as_tui = should_treat_as_tui_for_mobile(
+                    &session.runtime,
+                    session.in_alt_screen,
+                    session.frame_render_mode,
+                );
                 let has_scrollback = !session.scrollback.is_empty();
                 let runtime = session.runtime.clone();
                 let tmux_snapshot_req = if runtime == "tmux" && !render_as_tui {
@@ -1402,6 +1408,8 @@ async fn process_client_msg(
                 (
                     sb,
                     render_as_tui,
+                    session.in_alt_screen,
+                    session.frame_render_mode,
                     // tmux sessions use capture-pane snapshots; raw deferred replay
                     // of daemon scrollback corrupts frame TUIs on reconnect.
                     runtime != "tmux" && render_as_tui && has_scrollback,
@@ -1410,7 +1418,7 @@ async fn process_client_msg(
                     tmux_snapshot_req,
                 )
             } else {
-                (None, false, false, 0, "pty".to_string(), None)
+                (None, false, false, false, false, 0, "pty".to_string(), None)
             };
 
             if queue_deferred_replay {
@@ -1433,6 +1441,8 @@ async fn process_client_msg(
                 addr = %addr,
                 runtime = %runtime,
                 render_as_tui,
+                in_alt_screen,
+                frame_render_mode,
                 queue_deferred_replay,
                 scrollback_len,
                 text_replay_bytes = scrollback_bytes.as_ref().map(|b| b.len()).unwrap_or(0),
@@ -1476,6 +1486,7 @@ async fn process_client_msg(
             let ack = ServerMessage::SubscribeAck {
                 session_id,
                 in_alt_screen: render_as_tui,
+                runtime: Some(runtime),
             };
             if let Ok(text) = serde_json::to_string(&ack) {
                 let _ = tx.send(Message::Text(text)).await;
@@ -1863,14 +1874,19 @@ async fn process_client_msg(
                 let st = state.read().await;
                 if let Some(session) = st.sessions.get(&session_id) {
                     let max = max_bytes.unwrap_or(session.scrollback_max_bytes);
-                    if session.runtime == "tmux" {
-                        let render_as_tui = session.in_alt_screen || session.frame_render_mode;
+                    let render_as_tui = should_treat_as_tui_for_mobile(
+                        &session.runtime,
+                        session.in_alt_screen,
+                        session.frame_render_mode,
+                    );
+                    if session.runtime == "tmux" && !render_as_tui {
                         if let (Some(socket), Some(name)) =
                             (session.tmux_socket.clone(), session.tmux_session.clone())
                         {
-                            // For frame-rendered TUIs use visible pane snapshot only.
-                            // Full scrollback replay here can flood mobile and corrupt redraw.
-                            tmux_capture_req = Some((socket, name, max, !render_as_tui));
+                            // Non-alt tmux sessions use capture-pane with scrollback.
+                            // Alt-screen sessions fall back to daemon PTY scrollback because
+                            // tmux capture-pane history is viewport-limited there.
+                            tmux_capture_req = Some((socket, name, max, true));
                         }
                     }
                     tail_scrollback_bytes(session, max)
@@ -1888,9 +1904,19 @@ async fn process_client_msg(
                         let skip = total.saturating_sub(max);
                         (BASE64.encode(&snapshot[skip..]), total)
                     } else {
+                        tracing::debug!(
+                            session_id = %session_id,
+                            fallback_total_bytes = fallback_total_bytes,
+                            "tmux capture-pane unavailable, falling back to daemon scrollback replay"
+                        );
                         (BASE64.encode(&fallback_bytes), fallback_total_bytes)
                     }
                 } else {
+                    tracing::debug!(
+                        session_id = %session_id,
+                        fallback_total_bytes = fallback_total_bytes,
+                        "Using daemon scrollback replay for session_history"
+                    );
                     (BASE64.encode(&fallback_bytes), fallback_total_bytes)
                 };
 
@@ -3224,6 +3250,20 @@ fn should_ignore_resize_without_viewers(
     )
 }
 
+fn should_treat_as_tui_for_mobile(
+    runtime: &str,
+    in_alt_screen: bool,
+    frame_render_mode: bool,
+) -> bool {
+    // tmux sessions preserve pane state across reattach and can safely stream
+    // frame-rendered (non-alt) CLIs without forcing mobile suppression/reset.
+    // True alternate-screen sessions still need suppression semantics.
+    if runtime == "tmux" {
+        return in_alt_screen;
+    }
+    in_alt_screen || frame_render_mode
+}
+
 fn is_stale_resize_epoch(last_epoch: u64, incoming_epoch: Option<u64>) -> bool {
     incoming_epoch.is_some_and(|epoch| epoch <= last_epoch)
 }
@@ -3507,7 +3547,7 @@ mod tests {
         is_stale_resize_epoch, is_windows_reserved_device_name, resolve_resize_reason,
         sanitize_upload_file_name, scan_frame_sequences, should_enable_frame_mode,
         should_force_noop_resize, should_ignore_resize_without_viewers,
-        should_ignore_restore_resize, strip_terminal_report_sequences,
+        should_ignore_restore_resize, should_treat_as_tui_for_mobile, strip_terminal_report_sequences,
         strip_terminal_report_sequences_stateful, update_alt_screen_state,
         update_frame_render_state, DaemonState, PtyResizeReason, PtySession,
         DEFAULT_SCROLLBACK_MAX_BYTES, MAX_UPLOAD_FILE_NAME_BYTES,
@@ -3524,7 +3564,7 @@ mod tests {
 
     #[test]
     fn default_scrollback_is_large_enough_for_frame_clis() {
-        assert_eq!(DEFAULT_SCROLLBACK_MAX_BYTES, 2 * 1024 * 1024);
+        assert_eq!(DEFAULT_SCROLLBACK_MAX_BYTES, 8 * 1024 * 1024);
         assert!(DEFAULT_SCROLLBACK_MAX_BYTES > 64 * 1024);
     }
 
@@ -3803,6 +3843,18 @@ mod tests {
             1,
             PtyResizeReason::GeometryChange
         ));
+    }
+
+    #[test]
+    fn tmux_mobile_tui_gating_uses_real_alt_screen_only() {
+        // tmux frame-mode sessions that are not in true alt-screen should keep
+        // normal streaming + scrollback replay behavior.
+        assert!(!should_treat_as_tui_for_mobile("tmux", false, true));
+        assert!(!should_treat_as_tui_for_mobile("tmux", false, false));
+        // True alt-screen sessions must still use suppression/reconnect guards.
+        assert!(should_treat_as_tui_for_mobile("tmux", true, false));
+        // Legacy PTY runtime preserves historical frame-mode treatment.
+        assert!(should_treat_as_tui_for_mobile("pty", false, true));
     }
 
     #[test]

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -113,13 +113,13 @@ pub struct PushToken {
     pub platform: String, // "ios" | "android"
 }
 
-/// Default scrollback buffer size (512KB).
+/// Default scrollback buffer size (2MB).
 ///
 /// Codex/OpenCode-style frame UIs emit high-volume ANSI redraw traffic. A
 /// 64KB tail can roll over quickly and make reopened sessions appear to have
 /// "lost" earlier chat. Retaining a larger buffer keeps substantially more
 /// recoverable history while still bounding memory.
-const DEFAULT_SCROLLBACK_MAX_BYTES: usize = 512 * 1024;
+const DEFAULT_SCROLLBACK_MAX_BYTES: usize = 2 * 1024 * 1024;
 const ALT_ENTER_SEQS: &[&[u8]] = &[b"\x1b[?1049h", b"\x1b[?1047h", b"\x1b[?47h"];
 const ALT_LEAVE_SEQS: &[&[u8]] = &[b"\x1b[?1049l", b"\x1b[?1047l", b"\x1b[?47l"];
 const ALT_TRACK_TAIL_BYTES: usize = 7;
@@ -137,6 +137,8 @@ pub struct ResizeRequest {
 /// Active PTY session
 pub struct PtySession {
     pub session_id: String,
+    /// Execution runtime used by the wrapper (`pty` or `tmux`).
+    pub runtime: String,
     pub name: String,
     pub command: String,
     pub project_path: String,
@@ -594,8 +596,14 @@ async fn handle_pty_session(
     let name = reg_msg["name"].as_str().unwrap_or("Terminal").to_string();
     let command = reg_msg["command"].as_str().unwrap_or("shell").to_string();
     let project_path = reg_msg["project_path"].as_str().unwrap_or("").to_string();
+    let runtime = reg_msg["runtime"].as_str().unwrap_or("pty").to_lowercase();
 
-    tracing::info!("PTY session registered: {} ({})", name, session_id);
+    tracing::info!(
+        "PTY session registered: {} ({}) runtime={}",
+        name,
+        session_id,
+        runtime
+    );
 
     let (input_tx, mut input_rx) = mpsc::unbounded_channel::<Vec<u8>>();
     let (resize_tx, mut resize_rx) = mpsc::unbounded_channel::<ResizeRequest>();
@@ -611,6 +619,7 @@ async fn handle_pty_session(
             session_id.clone(),
             PtySession {
                 session_id: session_id.clone(),
+                runtime: runtime.clone(),
                 name: name.clone(),
                 command,
                 project_path,
@@ -2605,6 +2614,7 @@ async fn send_sessions_list(
             ws_port: port,
             started_at: s.started_at.to_rfc3339(),
             cli_type: s.cli_tracker.current().as_str().to_string(),
+            runtime: Some(s.runtime.clone()),
         })
         .collect();
     let msg = ServerMessage::Sessions { sessions: items };
@@ -2627,6 +2637,7 @@ async fn broadcast_sessions_update(state: &SharedState) {
             ws_port: port,
             started_at: s.started_at.to_rfc3339(),
             cli_type: s.cli_tracker.current().as_str().to_string(),
+            runtime: Some(s.runtime.clone()),
         })
         .collect();
     let msg = ServerMessage::Sessions { sessions: items };
@@ -3195,7 +3206,7 @@ mod tests {
 
     #[test]
     fn default_scrollback_is_large_enough_for_frame_clis() {
-        assert_eq!(DEFAULT_SCROLLBACK_MAX_BYTES, 512 * 1024);
+        assert_eq!(DEFAULT_SCROLLBACK_MAX_BYTES, 2 * 1024 * 1024);
         assert!(DEFAULT_SCROLLBACK_MAX_BYTES > 64 * 1024);
     }
 
@@ -3416,6 +3427,7 @@ mod tests {
                 session_id.clone(),
                 PtySession {
                     session_id: session_id.clone(),
+                    runtime: "pty".to_string(),
                     name: "Codex".to_string(),
                     command: "codex".to_string(),
                     project_path: "/tmp".to_string(),

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -1522,59 +1522,91 @@ async fn process_client_msg(
             );
             drop(st);
 
-            // Replay scrollback for text CLIs so chat history is visible.
-            // TUI apps (alt screen) get a clean redraw from SIGWINCH when
-            // the mobile resize arrives, so no replay needed.
-            if let Some(bytes) = scrollback_bytes {
-                let msg = ServerMessage::PtyBytes {
-                    session_id: session_id.clone(),
-                    data: BASE64.encode(&bytes),
+            // ── Step 1: wipe mobile's xterm.js buffer ──────────────────
+            //
+            // On every (re-)subscribe we first clear the client terminal so
+            // that replay data doesn't append to stale content from a prior
+            // subscribe.  TUI sessions enter alternate-screen (no scrollback,
+            // overwritten by the SIGWINCH-triggered redraw).  Text sessions
+            // erase the display *and* the scrollback buffer (\x1b[3J) so that
+            // the SessionHistory that follows is the only content.
+            {
+                let clear: &[u8] = if render_as_tui {
+                    // \x1b[?1049h  enter alternate screen
+                    // \x1b[2J      erase display
+                    // \x1b[H       cursor home
+                    b"\x1b[?1049h\x1b[2J\x1b[H"
+                } else {
+                    // \x1b[2J      erase display
+                    // \x1b[3J      erase scrollback (xterm extension, supported by xterm.js)
+                    // \x1b[H       cursor home
+                    b"\x1b[2J\x1b[3J\x1b[H"
                 };
-                if let Ok(text) = serde_json::to_string(&msg) {
+                let clear_msg = ServerMessage::PtyBytes {
+                    session_id: session_id.clone(),
+                    data: BASE64.encode(clear),
+                };
+                if let Ok(text) = serde_json::to_string(&clear_msg) {
                     let _ = tx.send(Message::Text(text)).await;
                 }
             }
 
-            if let Some((socket, name, max_bytes, include_scrollback)) = tmux_snapshot_req {
-                // Text sessions use capped subscribe depth; visible-pane captures
-                // (TUI sessions in alt-screen) pass max_lines=0 which is ignored.
-                let max_lines = if include_scrollback {
-                    SUBSCRIBE_SCROLLBACK_LINES
-                } else {
-                    0
-                };
-                if let Some(snapshot) =
-                    capture_tmux_history_with_retry(socket, name, include_scrollback, max_lines)
-                        .await
-                {
-                    let total_bytes = snapshot.len();
-                    let skip = total_bytes.saturating_sub(max_bytes);
-                    let bytes = &snapshot[skip..];
-                    let msg = ServerMessage::SessionHistory {
+            // ── Step 2: replay history (text sessions only) ─────────────
+            //
+            // TUI sessions skip all replay — the app redraws its full screen
+            // after the SIGWINCH triggered by the mobile resize.
+            if !render_as_tui {
+                if let Some(bytes) = scrollback_bytes {
+                    let msg = ServerMessage::PtyBytes {
                         session_id: session_id.clone(),
-                        data: BASE64.encode(bytes),
-                        total_bytes,
+                        data: BASE64.encode(&bytes),
                     };
                     if let Ok(text) = serde_json::to_string(&msg) {
                         let _ = tx.send(Message::Text(text)).await;
                     }
-                } else if let Some(fallback) = tmux_fallback_bytes {
-                    // capture-pane unavailable (socket not yet ready, tmux startup
-                    // race, etc.) – fall back to the daemon's in-memory PTY stream
-                    // so mobile at least sees recent output rather than a blank terminal.
-                    tracing::debug!(
-                        session_id = %session_id,
-                        fallback_bytes = fallback.len(),
-                        "capture-pane failed on subscribe; using daemon scrollback fallback"
-                    );
-                    let total_bytes = fallback.len();
-                    let msg = ServerMessage::SessionHistory {
-                        session_id: session_id.clone(),
-                        data: BASE64.encode(&fallback),
-                        total_bytes,
+                }
+
+                if let Some((socket, name, max_bytes, include_scrollback)) = tmux_snapshot_req {
+                    let max_lines = if include_scrollback {
+                        SUBSCRIBE_SCROLLBACK_LINES
+                    } else {
+                        0
                     };
-                    if let Ok(text) = serde_json::to_string(&msg) {
-                        let _ = tx.send(Message::Text(text)).await;
+                    if let Some(snapshot) =
+                        capture_tmux_history_with_retry(
+                            socket,
+                            name,
+                            include_scrollback,
+                            max_lines,
+                        )
+                        .await
+                    {
+                        let total_bytes = snapshot.len();
+                        let skip = total_bytes.saturating_sub(max_bytes);
+                        let bytes = &snapshot[skip..];
+                        let msg = ServerMessage::SessionHistory {
+                            session_id: session_id.clone(),
+                            data: BASE64.encode(bytes),
+                            total_bytes,
+                        };
+                        if let Ok(text) = serde_json::to_string(&msg) {
+                            let _ = tx.send(Message::Text(text)).await;
+                        }
+                    } else if let Some(fallback) = tmux_fallback_bytes {
+                        tracing::debug!(
+                            session_id = %session_id,
+                            fallback_bytes = fallback.len(),
+                            "capture-pane failed; using daemon scrollback fallback"
+                        );
+                        let total_bytes = fallback.len();
+                        let msg = ServerMessage::SessionHistory {
+                            session_id: session_id.clone(),
+                            data: BASE64.encode(&fallback),
+                            total_bytes,
+                        };
+                        if let Ok(text) = serde_json::to_string(&msg) {
+                            let _ = tx.send(Message::Text(text)).await;
+                        }
                     }
                 }
             }
@@ -1977,17 +2009,22 @@ async fn process_client_msg(
                         session.in_alt_screen,
                         session.frame_render_mode,
                     );
-                    if session.runtime == "tmux" && !render_as_tui {
+                    if render_as_tui {
+                        // TUI sessions redraw completely after SIGWINCH.
+                        // The daemon's scrollback for frame-rendering apps is
+                        // raw cursor-positioned output that renders as jumbled
+                        // content at any different terminal size.  Return empty.
+                        (Vec::new(), 0)
+                    } else if session.runtime == "tmux" {
                         if let (Some(socket), Some(name)) =
                             (session.tmux_socket.clone(), session.tmux_session.clone())
                         {
-                            // Non-alt tmux sessions use capture-pane with scrollback.
-                            // Alt-screen sessions fall back to daemon PTY scrollback because
-                            // tmux capture-pane history is viewport-limited there.
                             tmux_capture_req = Some((socket, name, max, true));
                         }
+                        tail_scrollback_bytes(session, max)
+                    } else {
+                        tail_scrollback_bytes(session, max)
                     }
-                    tail_scrollback_bytes(session, max)
                 } else {
                     (Vec::new(), 0)
                 }
@@ -3363,16 +3400,15 @@ fn should_ignore_resize_without_viewers(
 }
 
 fn should_treat_as_tui_for_mobile(
-    runtime: &str,
+    _runtime: &str,
     in_alt_screen: bool,
     frame_render_mode: bool,
 ) -> bool {
-    // tmux sessions preserve pane state across reattach and can safely stream
-    // frame-rendered (non-alt) CLIs without forcing mobile suppression/reset.
-    // True alternate-screen sessions still need suppression semantics.
-    if runtime == "tmux" {
-        return in_alt_screen;
-    }
+    // alternate-screen is disabled in tmux to preserve host terminal
+    // scrollback, so in_alt_screen is always false for tmux sessions.
+    // Use frame_render_mode so mobile's xterm.js enters alternate screen
+    // for TUI apps — without it, every frame draw pollutes main-buffer
+    // scrollback and the user sees jumbled content when scrolling up.
     in_alt_screen || frame_render_mode
 }
 
@@ -3407,11 +3443,12 @@ fn update_alt_screen_state(in_alt_screen: &mut bool, tail: &mut Vec<u8>, chunk: 
     tail.extend_from_slice(&scan[scan.len() - keep..]);
 }
 
-fn cli_defaults_to_frame_mode(_cli: CliType) -> bool {
-    // Do not pre-set frame mode based on app identity. The heuristic
-    // (heavy cursor-repositioning ops in output) detects frame-rendering
-    // behavior universally, regardless of which application is running.
-    false
+fn cli_defaults_to_frame_mode(cli: CliType) -> bool {
+    // Pre-set frame mode for known full-screen TUI apps so the very first
+    // mobile subscribe (before the output heuristic has seen enough frames)
+    // skips the desktop-width capture-pane and enters alt-screen immediately.
+    // The heuristic still runs and will detect any other frame-rendering app.
+    matches!(cli, CliType::Codex | CliType::OpenCode | CliType::Claude)
 }
 
 fn should_enable_frame_mode(cursor_ops: u32, erase_ops: u32) -> bool {
@@ -4026,12 +4063,10 @@ mod tests {
     }
 
     #[test]
-    fn frame_mode_not_preset_by_app_name() {
-        // frame_render_mode must be detected from observable output patterns,
-        // not pre-set based on which application is being launched.
-        assert!(!super::cli_defaults_to_frame_mode(CliType::Codex));
-        assert!(!super::cli_defaults_to_frame_mode(CliType::OpenCode));
-        assert!(!super::cli_defaults_to_frame_mode(CliType::Claude));
+    fn known_tui_apps_preset_frame_mode() {
+        assert!(super::cli_defaults_to_frame_mode(CliType::Codex));
+        assert!(super::cli_defaults_to_frame_mode(CliType::OpenCode));
+        assert!(super::cli_defaults_to_frame_mode(CliType::Claude));
         assert!(!super::cli_defaults_to_frame_mode(CliType::Terminal));
     }
 

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -9,7 +9,8 @@ use crate::detection::{
 use crate::filesystem::{config::FileSystemConfig, rate_limit::RateLimiter, FileSystemService};
 use crate::platform;
 use crate::protocol::{
-    ChangeType, ClientMessage, FileEncoding, FileSystemError, ServerMessage, SessionListItem,
+    ChangeType, ClientMessage, FileEncoding, FileSystemError, PtyResizeReason, ServerMessage,
+    SessionListItem,
 };
 use crate::session::{self, SessionInfo};
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
@@ -118,6 +119,14 @@ const ALT_ENTER_SEQS: &[&[u8]] = &[b"\x1b[?1049h", b"\x1b[?1047h", b"\x1b[?47h"]
 const ALT_LEAVE_SEQS: &[&[u8]] = &[b"\x1b[?1049l", b"\x1b[?1047l", b"\x1b[?47l"];
 const ALT_TRACK_TAIL_BYTES: usize = 7;
 
+#[derive(Debug, Clone, Copy)]
+pub struct ResizeRequest {
+    pub cols: u16,
+    pub rows: u16,
+    pub epoch: Option<u64>,
+    pub reason: PtyResizeReason,
+}
+
 /// Active PTY session
 pub struct PtySession {
     pub session_id: String,
@@ -126,7 +135,7 @@ pub struct PtySession {
     pub project_path: String,
     pub started_at: chrono::DateTime<Utc>,
     pub input_tx: mpsc::UnboundedSender<Vec<u8>>,
-    pub resize_tx: mpsc::UnboundedSender<(u16, u16, Option<u64>)>,
+    pub resize_tx: mpsc::UnboundedSender<ResizeRequest>,
     pub waiting_state: Option<WaitingState>,
     pub cli_tracker: CliTracker,
     pub last_wait_hash: Option<u64>,
@@ -142,6 +151,8 @@ pub struct PtySession {
     pub alt_track_tail: Vec<u8>,
     /// Latest accepted resize epoch from mobile (for stale resize rejection).
     pub last_resize_epoch: u64,
+    /// Last dimensions acknowledged by the PTY wrapper.
+    pub last_applied_size: Option<(u16, u16)>,
 }
 
 /// Daemon shared state
@@ -569,7 +580,7 @@ async fn handle_pty_session(
     tracing::info!("PTY session registered: {} ({})", name, session_id);
 
     let (input_tx, mut input_rx) = mpsc::unbounded_channel::<Vec<u8>>();
-    let (resize_tx, mut resize_rx) = mpsc::unbounded_channel::<(u16, u16, Option<u64>)>();
+    let (resize_tx, mut resize_rx) = mpsc::unbounded_channel::<ResizeRequest>();
 
     // Register session
     let pty_broadcast = {
@@ -595,6 +606,7 @@ async fn handle_pty_session(
                 in_alt_screen: false,
                 alt_track_tail: Vec::new(),
                 last_resize_epoch: 0,
+                last_applied_size: None,
             },
         );
         st.pty_broadcast.clone()
@@ -732,6 +744,12 @@ async fn handle_pty_session(
                                 let cols = msg["cols"].as_u64().unwrap_or(0).min(u16::MAX as u64) as u16;
                                 let rows = msg["rows"].as_u64().unwrap_or(0).min(u16::MAX as u64) as u16;
                                 let epoch = msg["epoch"].as_u64();
+                                {
+                                    let mut st = state.write().await;
+                                    if let Some(session) = st.sessions.get_mut(&session_id) {
+                                        session.last_applied_size = Some((cols, rows));
+                                    }
+                                }
                                 broadcast_pty_resized(&state, &session_id, cols, rows, epoch).await;
                             } else if msg["type"].as_str() == Some("session_ended") {
                                 exit_code = msg["exit_code"].as_i64().unwrap_or(0) as i32;
@@ -784,13 +802,30 @@ async fn handle_pty_session(
             // Resize from mobile
             result = resize_rx.recv() => {
                 match result {
-                    Some((cols, rows, epoch)) => {
+                    Some(mut req) => {
+                        let mut coalesced = 0usize;
+                        while let Ok(next) = resize_rx.try_recv() {
+                            req = next;
+                            coalesced += 1;
+                        }
+                        if coalesced > 0 {
+                            tracing::debug!(
+                                session_id = %session_id,
+                                coalesced,
+                                cols = req.cols,
+                                rows = req.rows,
+                                epoch = ?req.epoch,
+                                reason = req.reason.as_str(),
+                                "Coalesced resize burst to latest request"
+                            );
+                        }
                         let mut msg = serde_json::json!({
                             "type": "resize",
-                            "cols": cols,
-                            "rows": rows,
+                            "cols": req.cols,
+                            "rows": req.rows,
+                            "reason": req.reason.as_str(),
                         });
-                        if let Some(epoch) = epoch {
+                        if let Some(epoch) = req.epoch {
                             msg["epoch"] = serde_json::json!(epoch);
                         }
                         if tx.send(Message::Text(msg.to_string())).await.is_err() {
@@ -1340,9 +1375,11 @@ async fn process_client_msg(
             cols,
             rows,
             epoch,
+            reason,
         } => {
+            let reason = resolve_resize_reason(cols, rows, reason);
             let mut st = state.write().await;
-            let is_restore = cols == 0 && rows == 0;
+            let is_restore = reason == PtyResizeReason::DetachRestore;
             let viewer_count = st
                 .session_view_counts
                 .get(&session_id)
@@ -1353,11 +1390,19 @@ async fn process_client_msg(
                 .get(&addr)
                 .map(|views| views.contains(&session_id))
                 .unwrap_or(false);
+            let mut synthetic_ack: Option<(u16, u16, Option<u64>)> = None;
 
             if !is_restore && viewer_count == 0 {
                 tracing::debug!(
-                    "Ignoring PTY resize for {} (no active mobile viewers)",
-                    session_id
+                    session_id = %session_id,
+                    cols,
+                    rows,
+                    epoch = ?epoch,
+                    reason = reason.as_str(),
+                    viewer_count,
+                    sender_is_viewing,
+                    decision = "ignored_no_active_viewers",
+                    "Ignoring PTY resize with no active mobile viewers"
                 );
                 return Ok(());
             }
@@ -1366,10 +1411,15 @@ async fn process_client_msg(
             // other viewers are still attached to this session.
             if should_ignore_restore_resize(is_restore, viewer_count, sender_is_viewing) {
                 tracing::debug!(
-                    "Ignoring PTY restore for {} (viewer_count={}, sender_is_viewing={})",
-                    session_id,
+                    session_id = %session_id,
+                    cols,
+                    rows,
+                    epoch = ?epoch,
+                    reason = reason.as_str(),
                     viewer_count,
-                    sender_is_viewing
+                    sender_is_viewing,
+                    decision = "ignored_restore_guard",
+                    "Ignoring PTY restore while active viewers remain"
                 );
                 return Ok(());
             }
@@ -1377,17 +1427,77 @@ async fn process_client_msg(
             if let Some(session) = st.sessions.get_mut(&session_id) {
                 if is_stale_resize_epoch(session.last_resize_epoch, epoch) {
                     tracing::debug!(
-                        "Ignoring stale PTY resize for {} (epoch={:?}, last={})",
-                        session_id,
-                        epoch,
-                        session.last_resize_epoch
+                        session_id = %session_id,
+                        cols,
+                        rows,
+                        epoch = ?epoch,
+                        reason = reason.as_str(),
+                        viewer_count,
+                        sender_is_viewing,
+                        alt_screen = session.in_alt_screen,
+                        last_epoch = session.last_resize_epoch,
+                        decision = "ignored_stale_epoch",
+                        "Ignoring stale PTY resize"
                     );
                     return Ok(());
                 }
                 if let Some(epoch) = epoch {
                     session.last_resize_epoch = epoch;
                 }
-                let _ = session.resize_tx.send((cols, rows, epoch));
+
+                let ack_dims = session.last_applied_size.unwrap_or((cols, rows));
+                if reason == PtyResizeReason::KeyboardOverlay {
+                    tracing::debug!(
+                        session_id = %session_id,
+                        cols,
+                        rows,
+                        epoch = ?epoch,
+                        reason = reason.as_str(),
+                        viewer_count,
+                        sender_is_viewing,
+                        alt_screen = session.in_alt_screen,
+                        decision = "ignored_keyboard_overlay",
+                        "Ignoring keyboard-overlay resize (local UX only)"
+                    );
+                    synthetic_ack = Some((ack_dims.0, ack_dims.1, epoch));
+                } else if is_noop_resize(session.last_applied_size, cols, rows) {
+                    tracing::debug!(
+                        session_id = %session_id,
+                        cols,
+                        rows,
+                        epoch = ?epoch,
+                        reason = reason.as_str(),
+                        viewer_count,
+                        sender_is_viewing,
+                        alt_screen = session.in_alt_screen,
+                        decision = "ignored_noop",
+                        "Ignoring no-op PTY resize"
+                    );
+                    synthetic_ack = Some((ack_dims.0, ack_dims.1, epoch));
+                } else {
+                    tracing::debug!(
+                        session_id = %session_id,
+                        cols,
+                        rows,
+                        epoch = ?epoch,
+                        reason = reason.as_str(),
+                        viewer_count,
+                        sender_is_viewing,
+                        alt_screen = session.in_alt_screen,
+                        decision = "forwarded",
+                        "Forwarding PTY resize to wrapper"
+                    );
+                    let _ = session.resize_tx.send(ResizeRequest {
+                        cols,
+                        rows,
+                        epoch,
+                        reason,
+                    });
+                }
+            }
+            drop(st);
+            if let Some((ack_cols, ack_rows, ack_epoch)) = synthetic_ack {
+                broadcast_pty_resized(state, &session_id, ack_cols, ack_rows, ack_epoch).await;
             }
         }
         ClientMessage::Ping => {
@@ -2576,8 +2686,37 @@ fn truncate_to_max_chars(input: &mut String, max_chars: usize) {
     *input = trimmed;
 }
 
-fn should_ignore_restore_resize(is_restore: bool, viewer_count: usize, sender_is_viewing: bool) -> bool {
+fn should_ignore_restore_resize(
+    is_restore: bool,
+    viewer_count: usize,
+    sender_is_viewing: bool,
+) -> bool {
     is_restore && (viewer_count > 1 || (viewer_count == 1 && !sender_is_viewing))
+}
+
+fn resolve_resize_reason(
+    cols: u16,
+    rows: u16,
+    incoming: Option<PtyResizeReason>,
+) -> PtyResizeReason {
+    if cols == 0 || rows == 0 {
+        return PtyResizeReason::DetachRestore;
+    }
+
+    match incoming {
+        Some(reason @ PtyResizeReason::AttachInit)
+        | Some(reason @ PtyResizeReason::GeometryChange)
+        | Some(reason @ PtyResizeReason::ReconnectSync)
+        | Some(reason @ PtyResizeReason::KeyboardOverlay) => reason,
+        Some(PtyResizeReason::DetachRestore | PtyResizeReason::Unknown) => {
+            PtyResizeReason::GeometryChange
+        }
+        None => PtyResizeReason::GeometryChange,
+    }
+}
+
+fn is_noop_resize(last_applied: Option<(u16, u16)>, cols: u16, rows: u16) -> bool {
+    last_applied == Some((cols, rows))
 }
 
 fn is_stale_resize_epoch(last_epoch: u64, incoming_epoch: Option<u64>) -> bool {
@@ -2716,7 +2855,12 @@ fn is_path_watched(changed_path: &str, watched: &std::collections::HashSet<Strin
 async fn restore_pty_size(state: &SharedState, session_id: &str) {
     let st = state.read().await;
     if let Some(session) = st.sessions.get(session_id) {
-        let _ = session.resize_tx.send((0, 0, None));
+        let _ = session.resize_tx.send(ResizeRequest {
+            cols: 0,
+            rows: 0,
+            epoch: None,
+            reason: PtyResizeReason::DetachRestore,
+        });
     }
 }
 
@@ -2774,8 +2918,9 @@ async fn send_push_notifications(tokens: &[PushToken], title: &str, body: &str, 
 #[cfg(test)]
 mod tests {
     use super::{
-        build_upload_destination_path, is_stale_resize_epoch, is_windows_reserved_device_name,
-        sanitize_upload_file_name, should_ignore_restore_resize, update_alt_screen_state,
+        build_upload_destination_path, is_noop_resize, is_stale_resize_epoch,
+        is_windows_reserved_device_name, resolve_resize_reason, sanitize_upload_file_name,
+        should_ignore_restore_resize, update_alt_screen_state, PtyResizeReason,
         MAX_UPLOAD_FILE_NAME_BYTES,
     };
     use tempfile::TempDir;
@@ -2876,5 +3021,40 @@ mod tests {
         assert!(!is_stale_resize_epoch(5, Some(6)));
         assert!(is_stale_resize_epoch(5, Some(5)));
         assert!(is_stale_resize_epoch(5, Some(4)));
+    }
+
+    #[test]
+    fn resolve_resize_reason_prefers_restore_for_zero_dimensions() {
+        assert_eq!(
+            resolve_resize_reason(0, 24, Some(PtyResizeReason::GeometryChange)),
+            PtyResizeReason::DetachRestore
+        );
+        assert_eq!(
+            resolve_resize_reason(80, 0, Some(PtyResizeReason::AttachInit)),
+            PtyResizeReason::DetachRestore
+        );
+    }
+
+    #[test]
+    fn resolve_resize_reason_defaults_unknown_to_geometry_change() {
+        assert_eq!(
+            resolve_resize_reason(80, 24, None),
+            PtyResizeReason::GeometryChange
+        );
+        assert_eq!(
+            resolve_resize_reason(80, 24, Some(PtyResizeReason::Unknown)),
+            PtyResizeReason::GeometryChange
+        );
+        assert_eq!(
+            resolve_resize_reason(80, 24, Some(PtyResizeReason::DetachRestore)),
+            PtyResizeReason::GeometryChange
+        );
+    }
+
+    #[test]
+    fn noop_resize_detection_matches_last_applied_dimensions() {
+        assert!(is_noop_resize(Some((80, 24)), 80, 24));
+        assert!(!is_noop_resize(Some((80, 24)), 81, 24));
+        assert!(!is_noop_resize(None, 80, 24));
     }
 }

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -13,6 +13,7 @@ use crate::protocol::{
     SessionListItem,
 };
 use crate::session::{self, SessionInfo};
+use crate::tmux::sanitize_tmux_token;
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use chrono::Utc;
 use futures_util::{SinkExt, StreamExt};
@@ -3149,23 +3150,6 @@ fn truncate_to_max_chars(input: &mut String, max_chars: usize) {
     }
     let trimmed: String = input.chars().skip(len - max_chars).collect();
     *input = trimmed;
-}
-
-fn sanitize_tmux_token(raw: &str) -> String {
-    let mut out: String = raw
-        .chars()
-        .map(|ch| {
-            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
-                ch
-            } else {
-                '-'
-            }
-        })
-        .collect();
-    if out.is_empty() {
-        out.push_str("session");
-    }
-    out
 }
 
 fn tail_scrollback_bytes(session: &PtySession, max_bytes: usize) -> (Vec<u8>, usize) {

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -1422,14 +1422,6 @@ async fn process_client_msg(
         ClientMessage::Subscribe { session_id } => {
             tracing::debug!("Client subscribed to session: {}", session_id);
             let mut st = state.write().await;
-            let entry = st.mobile_views.entry(addr).or_default();
-            if entry.insert(session_id.clone()) {
-                let count = st
-                    .session_view_counts
-                    .entry(session_id.clone())
-                    .or_insert(0);
-                *count += 1;
-            }
 
             // Collect session state under one lock, then drop it before sending.
             let (
@@ -1535,18 +1527,12 @@ async fn process_client_msg(
             // Text main-buffer sessions erase display+scrollback so the next
             // replay starts from a deterministic baseline.
             //
-            // tmux frame sessions intentionally keep existing scrollback and only
-            // clear the visible display to avoid hard history loss on reattach.
             {
                 let clear: &[u8] = if mobile_in_alt_screen {
                     // \x1b[?1049h  enter alternate screen
                     // \x1b[2J      erase display
                     // \x1b[H       cursor home
                     b"\x1b[?1049h\x1b[2J\x1b[H"
-                } else if runtime == "tmux" && render_as_tui {
-                    // \x1b[2J      erase display
-                    // \x1b[H       cursor home
-                    b"\x1b[2J\x1b[H"
                 } else {
                     // \x1b[2J      erase display
                     // \x1b[3J      erase scrollback (xterm extension, supported by xterm.js)
@@ -1621,12 +1607,21 @@ async fn process_client_msg(
             // Always send SubscribeAck so mobile knows whether to suppress
             // stale bytes and enter alt-screen mode before resizing.
             let ack = ServerMessage::SubscribeAck {
-                session_id,
+                session_id: session_id.clone(),
                 in_alt_screen: mobile_in_alt_screen,
                 runtime: Some(runtime),
             };
             if let Ok(text) = serde_json::to_string(&ack) {
                 let _ = tx.send(Message::Text(text)).await;
+            }
+
+            // Register active view after initial clear/replay/ack sequence so
+            // live PTY stream can't interleave with bootstrap replay bytes.
+            let mut st = state.write().await;
+            let entry = st.mobile_views.entry(addr).or_default();
+            if entry.insert(session_id.clone()) {
+                let count = st.session_view_counts.entry(session_id).or_insert(0);
+                *count += 1;
             }
         }
         ClientMessage::Unsubscribe { session_id } => {

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -1562,7 +1562,9 @@ async fn process_client_msg(
                 .unwrap_or(false);
             let mut synthetic_ack: Option<(u16, u16, Option<u64>)> = None;
 
-            if !is_restore && viewer_count == 0 {
+            let ignore_no_viewer_resize =
+                should_ignore_resize_without_viewers(is_restore, viewer_count, reason);
+            if ignore_no_viewer_resize {
                 tracing::debug!(
                     session_id = %session_id,
                     cols,
@@ -1571,6 +1573,7 @@ async fn process_client_msg(
                     reason = reason.as_str(),
                     viewer_count,
                     sender_is_viewing,
+                    bootstrap_reason = matches!(reason, PtyResizeReason::AttachInit | PtyResizeReason::ReconnectSync),
                     decision = "ignored_no_active_viewers",
                     "Ignoring PTY resize with no active mobile viewers"
                 );
@@ -3206,6 +3209,21 @@ fn should_force_noop_resize(reason: PtyResizeReason) -> bool {
     )
 }
 
+fn should_ignore_resize_without_viewers(
+    is_restore: bool,
+    viewer_count: usize,
+    reason: PtyResizeReason,
+) -> bool {
+    if is_restore || viewer_count > 0 {
+        return false;
+    }
+
+    !matches!(
+        reason,
+        PtyResizeReason::AttachInit | PtyResizeReason::ReconnectSync
+    )
+}
+
 fn is_stale_resize_epoch(last_epoch: u64, incoming_epoch: Option<u64>) -> bool {
     incoming_epoch.is_some_and(|epoch| epoch <= last_epoch)
 }
@@ -3488,7 +3506,8 @@ mod tests {
         broadcast_pty_resized, build_upload_destination_path, capture_tmux_history, is_noop_resize,
         is_stale_resize_epoch, is_windows_reserved_device_name, resolve_resize_reason,
         sanitize_upload_file_name, scan_frame_sequences, should_enable_frame_mode,
-        should_force_noop_resize, should_ignore_restore_resize, strip_terminal_report_sequences,
+        should_force_noop_resize, should_ignore_resize_without_viewers,
+        should_ignore_restore_resize, strip_terminal_report_sequences,
         strip_terminal_report_sequences_stateful, update_alt_screen_state,
         update_frame_render_state, DaemonState, PtyResizeReason, PtySession,
         DEFAULT_SCROLLBACK_MAX_BYTES, MAX_UPLOAD_FILE_NAME_BYTES,
@@ -3755,6 +3774,35 @@ mod tests {
         assert!(!should_force_noop_resize(PtyResizeReason::DetachRestore));
         assert!(!should_force_noop_resize(PtyResizeReason::KeyboardOverlay));
         assert!(!should_force_noop_resize(PtyResizeReason::Unknown));
+    }
+
+    #[test]
+    fn no_viewer_guard_allows_bootstrap_resizes() {
+        assert!(should_ignore_resize_without_viewers(
+            false,
+            0,
+            PtyResizeReason::GeometryChange
+        ));
+        assert!(!should_ignore_resize_without_viewers(
+            false,
+            0,
+            PtyResizeReason::AttachInit
+        ));
+        assert!(!should_ignore_resize_without_viewers(
+            false,
+            0,
+            PtyResizeReason::ReconnectSync
+        ));
+        assert!(!should_ignore_resize_without_viewers(
+            true,
+            0,
+            PtyResizeReason::DetachRestore
+        ));
+        assert!(!should_ignore_resize_without_viewers(
+            false,
+            1,
+            PtyResizeReason::GeometryChange
+        ));
     }
 
     #[test]

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -173,6 +173,9 @@ pub struct PtySession {
     pub last_resize_epoch: u64,
     /// Last dimensions acknowledged by the PTY wrapper.
     pub last_applied_size: Option<(u16, u16)>,
+    /// Tail for raw mobile input filtering to handle escape sequences split
+    /// across websocket messages.
+    pub raw_input_tail: Vec<u8>,
 }
 
 /// Daemon shared state
@@ -651,6 +654,7 @@ async fn handle_pty_session(
                 frame_render_mode: initial_frame_mode,
                 last_resize_epoch: 0,
                 last_applied_size: None,
+                raw_input_tail: Vec::new(),
             },
         );
         st.pty_broadcast.clone()
@@ -1450,7 +1454,8 @@ async fn process_client_msg(
             }
 
             if let Some((socket, name, max_bytes, include_scrollback)) = tmux_snapshot_req {
-                if let Some(snapshot) = capture_tmux_history(socket, name, include_scrollback).await
+                if let Some(snapshot) =
+                    capture_tmux_history_with_retry(socket, name, include_scrollback).await
                 {
                     let total_bytes = snapshot.len();
                     let skip = total_bytes.saturating_sub(max_bytes);
@@ -1509,11 +1514,14 @@ async fn process_client_msg(
             raw,
             ..
         } => {
-            let st = state.read().await;
-            if let Some(session) = st.sessions.get(&session_id) {
+            let mut st = state.write().await;
+            if let Some(session) = st.sessions.get_mut(&session_id) {
                 let mut payload = text.into_bytes();
                 if raw {
-                    let (filtered, dropped) = strip_terminal_report_sequences(&payload);
+                    let (filtered, dropped) = strip_terminal_report_sequences_stateful(
+                        &mut session.raw_input_tail,
+                        &payload,
+                    );
                     if dropped > 0 {
                         tracing::debug!(
                             session_id = %session_id,
@@ -1868,20 +1876,20 @@ async fn process_client_msg(
                 }
             };
 
-            let (data, total_bytes) = if let Some((socket, name, max, include_scrollback)) =
-                tmux_capture_req
-            {
-                if let Some(snapshot) = capture_tmux_history(socket, name, include_scrollback).await
-                {
-                    let total = snapshot.len();
-                    let skip = total.saturating_sub(max);
-                    (BASE64.encode(&snapshot[skip..]), total)
+            let (data, total_bytes) =
+                if let Some((socket, name, max, include_scrollback)) = tmux_capture_req {
+                    if let Some(snapshot) =
+                        capture_tmux_history_with_retry(socket, name, include_scrollback).await
+                    {
+                        let total = snapshot.len();
+                        let skip = total.saturating_sub(max);
+                        (BASE64.encode(&snapshot[skip..]), total)
+                    } else {
+                        (BASE64.encode(&fallback_bytes), fallback_total_bytes)
+                    }
                 } else {
                     (BASE64.encode(&fallback_bytes), fallback_total_bytes)
-                }
-            } else {
-                (BASE64.encode(&fallback_bytes), fallback_total_bytes)
-            };
+                };
 
             let msg = ServerMessage::SessionHistory {
                 session_id,
@@ -3042,6 +3050,34 @@ async fn capture_tmux_history(
     .flatten()
 }
 
+fn snapshot_has_visible_content(bytes: &[u8]) -> bool {
+    bytes
+        .iter()
+        .any(|b| !matches!(b, b' ' | b'\t' | b'\r' | b'\n'))
+}
+
+async fn capture_tmux_history_with_retry(
+    socket: String,
+    session: String,
+    include_scrollback: bool,
+) -> Option<Vec<u8>> {
+    if include_scrollback {
+        return capture_tmux_history(socket, session, true).await;
+    }
+
+    const MAX_ATTEMPTS: usize = 8;
+    const RETRY_DELAY_MS: u64 = 120;
+    for attempt in 0..MAX_ATTEMPTS {
+        if let Some(snapshot) = capture_tmux_history(socket.clone(), session.clone(), false).await {
+            if snapshot_has_visible_content(&snapshot) || attempt + 1 == MAX_ATTEMPTS {
+                return Some(snapshot);
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(RETRY_DELAY_MS)).await;
+    }
+    None
+}
+
 fn is_terminal_report_csi(body: &[u8], final_byte: u8) -> bool {
     match final_byte {
         // Device Attributes response (e.g. ESC[>0;276;0c from xterm.js)
@@ -3056,46 +3092,75 @@ fn is_terminal_report_csi(body: &[u8], final_byte: u8) -> bool {
     }
 }
 
+#[cfg(test)]
 fn strip_terminal_report_sequences(input: &[u8]) -> (Vec<u8>, usize) {
-    let mut out = Vec::with_capacity(input.len());
+    let mut tail = Vec::new();
+    let (mut out, dropped) = strip_terminal_report_sequences_stateful(&mut tail, input);
+    if !tail.is_empty() {
+        out.extend_from_slice(&tail);
+    }
+    (out, dropped)
+}
+
+fn strip_terminal_report_sequences_stateful(tail: &mut Vec<u8>, input: &[u8]) -> (Vec<u8>, usize) {
+    let mut scan = Vec::with_capacity(tail.len() + input.len());
+    scan.extend_from_slice(tail);
+    scan.extend_from_slice(input);
+    tail.clear();
+
+    let mut out = Vec::with_capacity(scan.len());
     let mut i = 0usize;
     let mut dropped = 0usize;
 
-    while i < input.len() {
-        if input[i] == 0x1b && i + 2 < input.len() && input[i + 1] == b'[' {
-            let mut j = i + 2;
-            while j < input.len() {
-                let b = input[j];
-                // End of CSI sequence.
-                if b.is_ascii_alphabetic() || b == b'~' {
-                    let body = &input[i + 2..j];
-                    if is_terminal_report_csi(body, b) {
-                        dropped += 1;
+    while i < scan.len() {
+        if scan[i] == 0x1b {
+            if i + 1 >= scan.len() {
+                tail.extend_from_slice(&scan[i..]);
+                break;
+            }
+
+            if scan[i + 1] == b'[' {
+                let mut j = i + 2;
+                let mut handled = false;
+                while j < scan.len() {
+                    let b = scan[j];
+                    if b.is_ascii_alphabetic() || b == b'~' {
+                        let body = &scan[i + 2..j];
+                        if is_terminal_report_csi(body, b) {
+                            dropped += 1;
+                        } else {
+                            out.extend_from_slice(&scan[i..=j]);
+                        }
                         i = j + 1;
+                        handled = true;
                         break;
                     }
-                    // Not a report sequence; keep original bytes.
-                    out.extend_from_slice(&input[i..=j]);
-                    i = j + 1;
+                    if b == 0x1b || (j - i) > 64 {
+                        // Malformed sequence. Keep byte-for-byte fallback behavior.
+                        out.push(scan[i]);
+                        i += 1;
+                        handled = true;
+                        break;
+                    }
+                    j += 1;
+                }
+
+                if !handled {
+                    // Sequence is incomplete across websocket frames.
+                    tail.extend_from_slice(&scan[i..]);
                     break;
                 }
-                // Malformed / too long sequence; stop scanning to avoid pathological loops.
-                if b == 0x1b || (j - i) > 64 {
-                    out.push(input[i]);
-                    i += 1;
-                    break;
-                }
-                j += 1;
+                continue;
             }
-            if j >= input.len() {
-                out.push(input[i]);
-                i += 1;
-            }
-            continue;
         }
 
-        out.push(input[i]);
+        out.push(scan[i]);
         i += 1;
+    }
+
+    if tail.len() > 64 {
+        let keep = tail.len() - 64;
+        tail.drain(..keep);
     }
 
     (out, dropped)
@@ -3424,8 +3489,9 @@ mod tests {
         is_stale_resize_epoch, is_windows_reserved_device_name, resolve_resize_reason,
         sanitize_upload_file_name, scan_frame_sequences, should_enable_frame_mode,
         should_force_noop_resize, should_ignore_restore_resize, strip_terminal_report_sequences,
-        update_alt_screen_state, update_frame_render_state, DaemonState, PtyResizeReason,
-        PtySession, DEFAULT_SCROLLBACK_MAX_BYTES, MAX_UPLOAD_FILE_NAME_BYTES,
+        strip_terminal_report_sequences_stateful, update_alt_screen_state,
+        update_frame_render_state, DaemonState, PtyResizeReason, PtySession,
+        DEFAULT_SCROLLBACK_MAX_BYTES, MAX_UPLOAD_FILE_NAME_BYTES,
     };
     use crate::detection::{CliTracker, CliType};
     use base64::Engine as _;
@@ -3465,6 +3531,34 @@ mod tests {
         let (out, dropped) = strip_terminal_report_sequences(input);
         assert_eq!(dropped, 1);
         assert_eq!(out, b"helloworld");
+    }
+
+    #[test]
+    fn strip_terminal_reports_stateful_drops_split_da_reply() {
+        let mut tail = Vec::new();
+        let (out1, dropped1) = strip_terminal_report_sequences_stateful(&mut tail, b"\x1b[>");
+        assert_eq!(dropped1, 0);
+        assert!(out1.is_empty());
+        assert!(!tail.is_empty());
+
+        let (out2, dropped2) = strip_terminal_report_sequences_stateful(&mut tail, b"0;276;0c");
+        assert_eq!(dropped2, 1);
+        assert!(out2.is_empty());
+        assert!(tail.is_empty());
+    }
+
+    #[test]
+    fn strip_terminal_reports_stateful_preserves_split_arrow_key() {
+        let mut tail = Vec::new();
+        let (out1, dropped1) = strip_terminal_report_sequences_stateful(&mut tail, b"\x1b[");
+        assert_eq!(dropped1, 0);
+        assert!(out1.is_empty());
+        assert!(!tail.is_empty());
+
+        let (out2, dropped2) = strip_terminal_report_sequences_stateful(&mut tail, b"A");
+        assert_eq!(dropped2, 0);
+        assert_eq!(out2, b"\x1b[A");
+        assert!(tail.is_empty());
     }
 
     #[tokio::test]
@@ -3758,6 +3852,7 @@ mod tests {
                     frame_render_mode: true,
                     last_resize_epoch: 0,
                     last_applied_size: Some((95, 27)),
+                    raw_input_tail: Vec::new(),
                 },
             );
         }

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -701,7 +701,7 @@ async fn handle_pty_session(
                                     if let Ok(bytes) = BASE64.decode(data) {
                                         let _ = pty_broadcast.send((session_id.clone(), bytes.clone()));
 
-                                        // Accumulate scrollback and track alt screen state
+                                        // Accumulate scrollback and track render state.
                                         {
                                             let mut st = state.write().await;
                                             if let Some(session) = st.sessions.get_mut(&session_id) {
@@ -710,14 +710,23 @@ async fn handle_pty_session(
                                                 while session.scrollback.len() > session.scrollback_max_bytes {
                                                     session.scrollback.pop_front();
                                                 }
-                                                // Track alt-screen transitions across chunk
-                                                // boundaries so subscribe_ack reflects the
-                                                // current rendering mode reliably.
-                                                update_alt_screen_state(
-                                                    &mut session.in_alt_screen,
-                                                    &mut session.alt_track_tail,
-                                                    &bytes,
-                                                );
+                                                // tmux runtime runs with alternate-screen disabled
+                                                // during bootstrap, so raw 1049/1047 bytes from
+                                                // frame CLIs are not a reliable signal for
+                                                // mobile-side alt-screen policy.
+                                                if session.runtime == "tmux" {
+                                                    session.in_alt_screen = false;
+                                                    session.alt_track_tail.clear();
+                                                } else {
+                                                    // Track alt-screen transitions across chunk
+                                                    // boundaries so subscribe_ack reflects the
+                                                    // current rendering mode reliably.
+                                                    update_alt_screen_state(
+                                                        &mut session.in_alt_screen,
+                                                        &mut session.alt_track_tail,
+                                                        &bytes,
+                                                    );
+                                                }
                                                 let was_frame = session.frame_render_mode;
                                                 update_frame_render_state(
                                                     &mut session.frame_render_mode,
@@ -1445,33 +1454,19 @@ async fn process_client_msg(
                 );
                 let has_scrollback = !session.scrollback.is_empty();
                 let runtime = session.runtime.clone();
-                // alternate-screen is disabled in tmux so the host terminal (e.g.
-                // Konsole) never enters its own alt-screen and loses scrollback.
-                // This means in_alt_screen is always false for tmux sessions; we
-                // instead use frame_render_mode to distinguish between text CLIs
-                // (which get real scrollback history) and frame-rendering TUIs
-                // (which flood scrollback with cursor-home+clear frames and should
-                // instead get a visible-pane snapshot of their current screen state).
-                // frame_render_mode is detected from observable output patterns —
-                // any app that emits heavy cursor-repositioning qualifies, regardless
-                // of what the app is called.
+                // tmux sessions always replay from capture-pane. For frame-rendering
+                // CLIs we request only the visible pane; for text CLIs we include
+                // deeper scrollback.
                 let frame_render = session.frame_render_mode;
                 let tmux_snapshot_req = if runtime == "tmux" {
-                    if frame_render {
-                        // Frame-rendering TUIs redraw their entire screen on SIGWINCH.
-                        // Skip capture — it would be at desktop dimensions and get
-                        // immediately overwritten by the resize-triggered redraw.
-                        None
-                    } else {
-                        match (&session.tmux_socket, &session.tmux_session) {
-                            (Some(socket), Some(name)) => Some((
-                                socket.clone(),
-                                name.clone(),
-                                session.scrollback_max_bytes,
-                                true,
-                            )),
-                            _ => None,
-                        }
+                    match (&session.tmux_socket, &session.tmux_session) {
+                        (Some(socket), Some(name)) => Some((
+                            socket.clone(),
+                            name.clone(),
+                            session.scrollback_max_bytes,
+                            !frame_render,
+                        )),
+                        _ => None,
                     }
                 } else {
                     None
@@ -1481,9 +1476,9 @@ async fn process_client_msg(
                 } else {
                     None
                 };
-                // Daemon in-memory scrollback fallback for tmux text sessions when
-                // capture-pane is unavailable (socket startup race, etc.).
-                let tmux_fallback = if runtime == "tmux" && !frame_render && has_scrollback {
+                // Daemon in-memory fallback when capture-pane is unavailable
+                // (socket startup race, etc.).
+                let tmux_fallback = if runtime == "tmux" && has_scrollback {
                     Some(session.scrollback.iter().copied().collect::<Vec<u8>>())
                 } else {
                     None
@@ -1537,21 +1532,21 @@ async fn process_client_msg(
             // On every (re-)subscribe we first clear the client terminal so
             // that replay data doesn't append to stale content from a prior
             // subscribe. Sessions in mobile alternate-screen use 1049h clear.
-            // Main-buffer sessions erase display+scrollback so the next render
-            // starts from a deterministic baseline.
+            // Text main-buffer sessions erase display+scrollback so the next
+            // replay starts from a deterministic baseline.
             //
-            // tmux frame sessions intentionally stay in the main buffer to
-            // preserve mobile-side scrollback and manual panning.
-            //
-            // Text sessions
-            // erase the display *and* the scrollback buffer (\x1b[3J) so that
-            // the SessionHistory that follows is the only content.
+            // tmux frame sessions intentionally keep existing scrollback and only
+            // clear the visible display to avoid hard history loss on reattach.
             {
                 let clear: &[u8] = if mobile_in_alt_screen {
                     // \x1b[?1049h  enter alternate screen
                     // \x1b[2J      erase display
                     // \x1b[H       cursor home
                     b"\x1b[?1049h\x1b[2J\x1b[H"
+                } else if runtime == "tmux" && render_as_tui {
+                    // \x1b[2J      erase display
+                    // \x1b[H       cursor home
+                    b"\x1b[2J\x1b[H"
                 } else {
                     // \x1b[2J      erase display
                     // \x1b[3J      erase scrollback (xterm extension, supported by xterm.js)
@@ -1567,10 +1562,9 @@ async fn process_client_msg(
                 }
             }
 
-            // ── Step 2: replay history (text sessions only) ─────────────
+            // ── Step 2: replay history ────────────────────────────────────
             //
-            // TUI sessions skip all replay — the app redraws its full screen
-            // after the SIGWINCH triggered by the mobile resize.
+            // PTY text sessions replay daemon scrollback.
             if !render_as_tui {
                 if let Some(bytes) = scrollback_bytes {
                     let msg = ServerMessage::PtyBytes {
@@ -1581,43 +1575,45 @@ async fn process_client_msg(
                         let _ = tx.send(Message::Text(text)).await;
                     }
                 }
+            }
 
-                if let Some((socket, name, max_bytes, include_scrollback)) = tmux_snapshot_req {
-                    let max_lines = if include_scrollback {
-                        SUBSCRIBE_SCROLLBACK_LINES
-                    } else {
-                        0
+            // tmux sessions always get an authoritative pane snapshot on
+            // subscribe. Frame-rendered CLIs request visible pane only.
+            if let Some((socket, name, max_bytes, include_scrollback)) = tmux_snapshot_req {
+                let max_lines = if include_scrollback {
+                    SUBSCRIBE_SCROLLBACK_LINES
+                } else {
+                    0
+                };
+                if let Some(snapshot) =
+                    capture_tmux_history_with_retry(socket, name, include_scrollback, max_lines)
+                        .await
+                {
+                    let total_bytes = snapshot.len();
+                    let skip = total_bytes.saturating_sub(max_bytes);
+                    let bytes = &snapshot[skip..];
+                    let msg = ServerMessage::SessionHistory {
+                        session_id: session_id.clone(),
+                        data: BASE64.encode(bytes),
+                        total_bytes,
                     };
-                    if let Some(snapshot) =
-                        capture_tmux_history_with_retry(socket, name, include_scrollback, max_lines)
-                            .await
-                    {
-                        let total_bytes = snapshot.len();
-                        let skip = total_bytes.saturating_sub(max_bytes);
-                        let bytes = &snapshot[skip..];
-                        let msg = ServerMessage::SessionHistory {
-                            session_id: session_id.clone(),
-                            data: BASE64.encode(bytes),
-                            total_bytes,
-                        };
-                        if let Ok(text) = serde_json::to_string(&msg) {
-                            let _ = tx.send(Message::Text(text)).await;
-                        }
-                    } else if let Some(fallback) = tmux_fallback_bytes {
-                        tracing::debug!(
-                            session_id = %session_id,
-                            fallback_bytes = fallback.len(),
-                            "capture-pane failed; using daemon scrollback fallback"
-                        );
-                        let total_bytes = fallback.len();
-                        let msg = ServerMessage::SessionHistory {
-                            session_id: session_id.clone(),
-                            data: BASE64.encode(&fallback),
-                            total_bytes,
-                        };
-                        if let Ok(text) = serde_json::to_string(&msg) {
-                            let _ = tx.send(Message::Text(text)).await;
-                        }
+                    if let Ok(text) = serde_json::to_string(&msg) {
+                        let _ = tx.send(Message::Text(text)).await;
+                    }
+                } else if let Some(fallback) = tmux_fallback_bytes {
+                    tracing::debug!(
+                        session_id = %session_id,
+                        fallback_bytes = fallback.len(),
+                        "capture-pane failed; using daemon scrollback fallback"
+                    );
+                    let total_bytes = fallback.len();
+                    let msg = ServerMessage::SessionHistory {
+                        session_id: session_id.clone(),
+                        data: BASE64.encode(&fallback),
+                        total_bytes,
+                    };
+                    if let Ok(text) = serde_json::to_string(&msg) {
+                        let _ = tx.send(Message::Text(text)).await;
                     }
                 }
             }
@@ -2020,19 +2016,18 @@ async fn process_client_msg(
                         session.in_alt_screen,
                         session.frame_render_mode,
                     );
-                    if render_as_tui {
-                        // TUI sessions redraw completely after SIGWINCH.
-                        // The daemon's scrollback for frame-rendering apps is
-                        // raw cursor-positioned output that renders as jumbled
-                        // content at any different terminal size.  Return empty.
-                        (Vec::new(), 0)
-                    } else if session.runtime == "tmux" {
+                    if session.runtime == "tmux" {
                         if let (Some(socket), Some(name)) =
                             (session.tmux_socket.clone(), session.tmux_session.clone())
                         {
-                            tmux_capture_req = Some((socket, name, max, true));
+                            tmux_capture_req = Some((socket, name, max, !render_as_tui));
                         }
                         tail_scrollback_bytes(session, max)
+                    } else if render_as_tui {
+                        // PTY frame-rendering sessions can only safely replay
+                        // their live stream; historical replay is often malformed
+                        // after geometry changes.
+                        (Vec::new(), 0)
                     } else {
                         tail_scrollback_bytes(session, max)
                     }
@@ -3395,15 +3390,15 @@ fn should_ignore_resize_without_viewers(
 }
 
 fn should_treat_as_tui_for_mobile(
-    _runtime: &str,
+    runtime: &str,
     in_alt_screen: bool,
     frame_render_mode: bool,
 ) -> bool {
-    // alternate-screen is disabled in tmux to preserve host terminal
-    // scrollback, so in_alt_screen is always false for tmux sessions.
-    // Use frame_render_mode so mobile's xterm.js enters alternate screen
-    // for TUI apps — without it, every frame draw pollutes main-buffer
-    // scrollback and the user sees jumbled content when scrolling up.
+    if runtime == "tmux" {
+        // tmux runtime keeps alternate-screen disabled at bootstrap, so use
+        // frame-render mode as the TUI gate.
+        return frame_render_mode;
+    }
     in_alt_screen || frame_render_mode
 }
 
@@ -3412,15 +3407,15 @@ fn should_mobile_enter_alt_screen(
     in_alt_screen: bool,
     frame_render_mode: bool,
 ) -> bool {
-    // Preserve real alternate-screen behavior when the app explicitly requests it.
-    if in_alt_screen {
-        return true;
-    }
     // tmux runtime intentionally disables alternate-screen at the host level.
-    // For frame-rendering apps under tmux we keep mobile in the main buffer so
-    // users can retain scrollback and pan through prior output.
+    // Ignore raw 1049/1047 bytes from pane output and keep mobile in main
+    // buffer for deterministic replay + scrollback behavior.
     if runtime == "tmux" {
         return false;
+    }
+    // Preserve real alternate-screen behavior for non-tmux runtimes.
+    if in_alt_screen {
+        return true;
     }
     frame_render_mode
 }
@@ -4039,12 +4034,10 @@ mod tests {
 
     #[test]
     fn tui_gating_uses_frame_render_for_all_runtimes() {
-        // alternate-screen is disabled in tmux so in_alt_screen is always
-        // false there. frame_render_mode must still gate replay behavior for
-        // tmux sessions to avoid dumping raw frame redraw traffic as history.
+        // tmux runtime ignores raw alt-screen bytes and relies on frame mode.
         assert!(should_treat_as_tui_for_mobile("tmux", false, true));
         assert!(!should_treat_as_tui_for_mobile("tmux", false, false));
-        assert!(should_treat_as_tui_for_mobile("tmux", true, false));
+        assert!(!should_treat_as_tui_for_mobile("tmux", true, false));
         assert!(should_treat_as_tui_for_mobile("pty", false, true));
         assert!(!should_treat_as_tui_for_mobile("pty", false, false));
     }
@@ -4053,7 +4046,7 @@ mod tests {
     fn mobile_alt_screen_policy_preserves_tmux_scrollback() {
         assert!(!should_mobile_enter_alt_screen("tmux", false, true));
         assert!(!should_mobile_enter_alt_screen("tmux", false, false));
-        assert!(should_mobile_enter_alt_screen("tmux", true, false));
+        assert!(!should_mobile_enter_alt_screen("tmux", true, false));
         assert!(should_mobile_enter_alt_screen("pty", false, true));
         assert!(!should_mobile_enter_alt_screen("pty", false, false));
     }

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -1461,19 +1461,40 @@ async fn process_client_msg(
                     );
                     synthetic_ack = Some((ack_dims.0, ack_dims.1, epoch));
                 } else if is_noop_resize(session.last_applied_size, cols, rows) {
-                    tracing::debug!(
-                        session_id = %session_id,
-                        cols,
-                        rows,
-                        epoch = ?epoch,
-                        reason = reason.as_str(),
-                        viewer_count,
-                        sender_is_viewing,
-                        alt_screen = session.in_alt_screen,
-                        decision = "ignored_noop",
-                        "Ignoring no-op PTY resize"
-                    );
-                    synthetic_ack = Some((ack_dims.0, ack_dims.1, epoch));
+                    if should_force_noop_resize(reason) {
+                        tracing::debug!(
+                            session_id = %session_id,
+                            cols,
+                            rows,
+                            epoch = ?epoch,
+                            reason = reason.as_str(),
+                            viewer_count,
+                            sender_is_viewing,
+                            alt_screen = session.in_alt_screen,
+                            decision = "forwarded_noop_refresh",
+                            "Forwarding no-op PTY resize to force redraw"
+                        );
+                        let _ = session.resize_tx.send(ResizeRequest {
+                            cols,
+                            rows,
+                            epoch,
+                            reason,
+                        });
+                    } else {
+                        tracing::debug!(
+                            session_id = %session_id,
+                            cols,
+                            rows,
+                            epoch = ?epoch,
+                            reason = reason.as_str(),
+                            viewer_count,
+                            sender_is_viewing,
+                            alt_screen = session.in_alt_screen,
+                            decision = "ignored_noop",
+                            "Ignoring no-op PTY resize"
+                        );
+                        synthetic_ack = Some((ack_dims.0, ack_dims.1, epoch));
+                    }
                 } else {
                     tracing::debug!(
                         session_id = %session_id,
@@ -2719,6 +2740,13 @@ fn is_noop_resize(last_applied: Option<(u16, u16)>, cols: u16, rows: u16) -> boo
     last_applied == Some((cols, rows))
 }
 
+fn should_force_noop_resize(reason: PtyResizeReason) -> bool {
+    matches!(
+        reason,
+        PtyResizeReason::AttachInit | PtyResizeReason::ReconnectSync
+    )
+}
+
 fn is_stale_resize_epoch(last_epoch: u64, incoming_epoch: Option<u64>) -> bool {
     incoming_epoch.is_some_and(|epoch| epoch <= last_epoch)
 }
@@ -2920,7 +2948,8 @@ mod tests {
     use super::{
         build_upload_destination_path, is_noop_resize, is_stale_resize_epoch,
         is_windows_reserved_device_name, resolve_resize_reason, sanitize_upload_file_name,
-        should_ignore_restore_resize, update_alt_screen_state, PtyResizeReason,
+        should_force_noop_resize, should_ignore_restore_resize, update_alt_screen_state,
+        PtyResizeReason,
         MAX_UPLOAD_FILE_NAME_BYTES,
     };
     use tempfile::TempDir;
@@ -3056,5 +3085,15 @@ mod tests {
         assert!(is_noop_resize(Some((80, 24)), 80, 24));
         assert!(!is_noop_resize(Some((80, 24)), 81, 24));
         assert!(!is_noop_resize(None, 80, 24));
+    }
+
+    #[test]
+    fn force_noop_resize_only_for_attach_and_reconnect() {
+        assert!(should_force_noop_resize(PtyResizeReason::AttachInit));
+        assert!(should_force_noop_resize(PtyResizeReason::ReconnectSync));
+        assert!(!should_force_noop_resize(PtyResizeReason::GeometryChange));
+        assert!(!should_force_noop_resize(PtyResizeReason::DetachRestore));
+        assert!(!should_force_noop_resize(PtyResizeReason::KeyboardOverlay));
+        assert!(!should_force_noop_resize(PtyResizeReason::Unknown));
     }
 }

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -113,8 +113,13 @@ pub struct PushToken {
     pub platform: String, // "ios" | "android"
 }
 
-/// Default scrollback buffer size (64KB)
-const DEFAULT_SCROLLBACK_MAX_BYTES: usize = 64 * 1024;
+/// Default scrollback buffer size (512KB).
+///
+/// Codex/OpenCode-style frame UIs emit high-volume ANSI redraw traffic. A
+/// 64KB tail can roll over quickly and make reopened sessions appear to have
+/// "lost" earlier chat. Retaining a larger buffer keeps substantially more
+/// recoverable history while still bounding memory.
+const DEFAULT_SCROLLBACK_MAX_BYTES: usize = 512 * 1024;
 const ALT_ENTER_SEQS: &[&[u8]] = &[b"\x1b[?1049h", b"\x1b[?1047h", b"\x1b[?47h"];
 const ALT_LEAVE_SEQS: &[&[u8]] = &[b"\x1b[?1049l", b"\x1b[?1047l", b"\x1b[?47l"];
 const ALT_TRACK_TAIL_BYTES: usize = 7;
@@ -173,6 +178,9 @@ pub struct DaemonState {
     pub push_tokens: Vec<PushToken>,
     pub mobile_views: HashMap<SocketAddr, std::collections::HashSet<String>>,
     pub session_view_counts: HashMap<String, usize>,
+    /// Sessions that should receive one deferred replay after first
+    /// post-subscribe PTY resize ack (per mobile client).
+    pub pending_tui_replay: HashMap<SocketAddr, std::collections::HashSet<String>>,
     pub file_system: std::sync::Arc<FileSystemService>,
     pub file_watch_subscriptions: HashMap<SocketAddr, std::collections::HashSet<String>>,
     pub file_watch_counts: HashMap<String, usize>,
@@ -205,6 +213,7 @@ impl DaemonState {
             push_tokens: Vec::new(),
             mobile_views: HashMap::new(),
             session_view_counts: HashMap::new(),
+            pending_tui_replay: HashMap::new(),
             file_system,
             file_watch_subscriptions: HashMap::new(),
             file_watch_counts: HashMap::new(),
@@ -871,6 +880,7 @@ async fn handle_pty_session(
     let was_present = {
         let mut st = state.write().await;
         if st.sessions.remove(&session_id).is_some() {
+            clear_pending_tui_replay_for_session(&mut st, &session_id);
             // Notify about session end
             let msg = ServerMessage::SessionEnded {
                 session_id: session_id.clone(),
@@ -1334,18 +1344,49 @@ async fn process_client_msg(
             }
 
             // Collect session state under one lock, then drop it before sending.
-            let (scrollback_bytes, render_as_tui) =
+            let (scrollback_bytes, render_as_tui, queue_deferred_replay, scrollback_len) =
                 if let Some(session) = st.sessions.get(&session_id) {
                     let render_as_tui = session.in_alt_screen || session.frame_render_mode;
-                    let sb = if !render_as_tui && !session.scrollback.is_empty() {
+                    let has_scrollback = !session.scrollback.is_empty();
+                    let sb = if !render_as_tui && has_scrollback {
                         Some(session.scrollback.iter().copied().collect::<Vec<u8>>())
                     } else {
                         None
                     };
-                    (sb, render_as_tui)
+                    (
+                        sb,
+                        render_as_tui,
+                        render_as_tui && has_scrollback,
+                        session.scrollback.len(),
+                    )
                 } else {
-                    (None, false)
+                    (None, false, false, 0)
                 };
+
+            if queue_deferred_replay {
+                st.pending_tui_replay
+                    .entry(addr)
+                    .or_default()
+                    .insert(session_id.clone());
+            } else {
+                let mut remove_entry = false;
+                if let Some(pending) = st.pending_tui_replay.get_mut(&addr) {
+                    pending.remove(&session_id);
+                    remove_entry = pending.is_empty();
+                }
+                if remove_entry {
+                    st.pending_tui_replay.remove(&addr);
+                }
+            }
+            tracing::debug!(
+                session_id = %session_id,
+                addr = %addr,
+                render_as_tui,
+                queue_deferred_replay,
+                scrollback_len,
+                text_replay_bytes = scrollback_bytes.as_ref().map(|b| b.len()).unwrap_or(0),
+                "Subscribe replay decision"
+            );
             drop(st);
 
             // Replay scrollback for text CLIs so chat history is visible.
@@ -1374,6 +1415,14 @@ async fn process_client_msg(
         ClientMessage::Unsubscribe { session_id } => {
             tracing::debug!("Client unsubscribed from session: {}", session_id);
             let mut st = state.write().await;
+            let mut remove_entry = false;
+            if let Some(pending) = st.pending_tui_replay.get_mut(&addr) {
+                pending.remove(&session_id);
+                remove_entry = pending.is_empty();
+            }
+            if remove_entry {
+                st.pending_tui_replay.remove(&addr);
+            }
             if let Some(entry) = st.mobile_views.get_mut(&addr) {
                 if entry.remove(&session_id) {
                     if let Some(count) = st.session_view_counts.get_mut(&session_id) {
@@ -1603,6 +1652,7 @@ async fn process_client_msg(
                     drop(session);
                     // Clean up view counts for this session
                     st.session_view_counts.remove(&session_id);
+                    clear_pending_tui_replay_for_session(&mut st, &session_id);
                     for views in st.mobile_views.values_mut() {
                         views.remove(&session_id);
                     }
@@ -2658,23 +2708,95 @@ async fn broadcast_pty_resized(
     rows: u16,
     epoch: Option<u64>,
 ) {
-    let st = state.read().await;
     let msg = ServerMessage::PtyResized {
         session_id: session_id.to_string(),
         cols,
         rows,
         epoch,
     };
-    if let Ok(msg_str) = serde_json::to_string(&msg) {
-        for (addr, client) in &st.mobile_clients {
-            let is_viewing = st
-                .mobile_views
-                .get(addr)
-                .map(|views| views.contains(session_id))
-                .unwrap_or(false);
-            if is_viewing {
-                let _ = client.try_send(Message::Text(msg_str.clone()));
+    let Ok(msg_str) = serde_json::to_string(&msg) else {
+        return;
+    };
+
+    let mut ack_clients: Vec<mpsc::Sender<Message>> = Vec::new();
+    let mut replay_clients: Vec<mpsc::Sender<Message>> = Vec::new();
+    let mut replay_payload: Option<String> = None;
+    let mut replay_scrollback_len = 0usize;
+
+    {
+        let mut st = state.write().await;
+        let viewing_addrs: Vec<SocketAddr> = st
+            .mobile_views
+            .iter()
+            .filter_map(|(addr, views)| views.contains(session_id).then_some(*addr))
+            .collect();
+
+        if !viewing_addrs.is_empty() {
+            for addr in &viewing_addrs {
+                if let Some(client) = st.mobile_clients.get(addr) {
+                    ack_clients.push(client.clone());
+                }
             }
+
+            let replay_addrs: Vec<SocketAddr> = viewing_addrs
+                .iter()
+                .copied()
+                .filter(|addr| {
+                    st.pending_tui_replay
+                        .get(addr)
+                        .map(|pending| pending.contains(session_id))
+                        .unwrap_or(false)
+                })
+                .collect();
+
+            if !replay_addrs.is_empty() {
+                if let Some(session) = st.sessions.get(session_id) {
+                    if !session.scrollback.is_empty() {
+                        replay_scrollback_len = session.scrollback.len();
+                        let bytes: Vec<u8> = session.scrollback.iter().copied().collect();
+                        let replay_msg = ServerMessage::PtyBytes {
+                            session_id: session_id.to_string(),
+                            data: BASE64.encode(&bytes),
+                        };
+                        replay_payload = serde_json::to_string(&replay_msg).ok();
+                    }
+                }
+
+                for addr in replay_addrs {
+                    if let Some(client) = st.mobile_clients.get(&addr) {
+                        replay_clients.push(client.clone());
+                    }
+                    let mut remove_entry = false;
+                    if let Some(pending) = st.pending_tui_replay.get_mut(&addr) {
+                        pending.remove(session_id);
+                        remove_entry = pending.is_empty();
+                    }
+                    if remove_entry {
+                        st.pending_tui_replay.remove(&addr);
+                    }
+                }
+            }
+        }
+    }
+
+    tracing::debug!(
+        session_id = %session_id,
+        cols,
+        rows,
+        epoch = ?epoch,
+        ack_clients = ack_clients.len(),
+        replay_clients = replay_clients.len(),
+        replay_scrollback_len,
+        replay_payload_len = replay_payload.as_ref().map(|s| s.len()).unwrap_or(0),
+        "Broadcasted pty_resized"
+    );
+
+    for client in ack_clients {
+        let _ = client.try_send(Message::Text(msg_str.clone()));
+    }
+    if let Some(payload) = replay_payload {
+        for client in replay_clients {
+            let _ = client.try_send(Message::Text(payload.clone()));
         }
     }
 }
@@ -2826,8 +2948,7 @@ fn scan_frame_sequences(chunk: &[u8]) -> (u32, u32) {
         }
 
         let mut j = i + 2;
-        while j < chunk.len()
-            && (chunk[j].is_ascii_digit() || chunk[j] == b';' || chunk[j] == b'?')
+        while j < chunk.len() && (chunk[j].is_ascii_digit() || chunk[j] == b';' || chunk[j] == b'?')
         {
             j += 1;
         }
@@ -2910,6 +3031,7 @@ fn build_notification_text(
 async fn cleanup_client_state(state: &SharedState, addr: SocketAddr) {
     let (sessions_to_restore, to_unwatch) = {
         let mut st = state.write().await;
+        st.pending_tui_replay.remove(&addr);
 
         let sessions_to_restore = match st.mobile_views.remove(&addr) {
             Some(sessions) => {
@@ -2973,6 +3095,19 @@ fn is_path_watched(changed_path: &str, watched: &std::collections::HashSet<Strin
         return watched.contains(&parent);
     }
     false
+}
+
+fn clear_pending_tui_replay_for_session(st: &mut DaemonState, session_id: &str) {
+    let mut empty_addrs = Vec::new();
+    for (addr, pending) in st.pending_tui_replay.iter_mut() {
+        pending.remove(session_id);
+        if pending.is_empty() {
+            empty_addrs.push(*addr);
+        }
+    }
+    for addr in empty_addrs {
+        st.pending_tui_replay.remove(&addr);
+    }
 }
 
 async fn restore_pty_size(state: &SharedState, session_id: &str) {
@@ -3041,15 +3176,28 @@ async fn send_push_notifications(tokens: &[PushToken], title: &str, body: &str, 
 #[cfg(test)]
 mod tests {
     use super::{
-        build_upload_destination_path, is_noop_resize, is_stale_resize_epoch,
-        is_windows_reserved_device_name, resolve_resize_reason, sanitize_upload_file_name,
-        scan_frame_sequences, should_enable_frame_mode, should_force_noop_resize,
-        should_ignore_restore_resize, update_alt_screen_state, update_frame_render_state,
-        PtyResizeReason,
-        MAX_UPLOAD_FILE_NAME_BYTES,
+        broadcast_pty_resized, build_upload_destination_path, is_noop_resize,
+        is_stale_resize_epoch, is_windows_reserved_device_name, resolve_resize_reason,
+        sanitize_upload_file_name, scan_frame_sequences, should_enable_frame_mode,
+        should_force_noop_resize, should_ignore_restore_resize, update_alt_screen_state,
+        update_frame_render_state, DaemonState, PtyResizeReason, PtySession,
+        DEFAULT_SCROLLBACK_MAX_BYTES, MAX_UPLOAD_FILE_NAME_BYTES,
     };
-    use crate::detection::CliType;
+    use crate::detection::{CliTracker, CliType};
+    use base64::Engine as _;
+    use chrono::Utc;
+    use std::collections::VecDeque;
+    use std::sync::Arc;
     use tempfile::TempDir;
+    use tokio::sync::{mpsc, RwLock};
+    use tokio::time::{timeout, Duration};
+    use tokio_tungstenite::tungstenite::Message;
+
+    #[test]
+    fn default_scrollback_is_large_enough_for_frame_clis() {
+        assert_eq!(DEFAULT_SCROLLBACK_MAX_BYTES, 512 * 1024);
+        assert!(DEFAULT_SCROLLBACK_MAX_BYTES > 64 * 1024);
+    }
 
     #[test]
     fn sanitize_upload_file_name_replaces_invalid_chars() {
@@ -3232,5 +3380,128 @@ mod tests {
         assert!(super::cli_defaults_to_frame_mode(CliType::OpenCode));
         assert!(!super::cli_defaults_to_frame_mode(CliType::Claude));
         assert!(!super::cli_defaults_to_frame_mode(CliType::Terminal));
+    }
+
+    #[tokio::test]
+    async fn pty_resized_replays_pending_tui_scrollback_only_once() {
+        let state = Arc::new(RwLock::new(DaemonState::new(9847)));
+        let addr: std::net::SocketAddr = "127.0.0.1:40001".parse().expect("socket addr");
+        let session_id = "test-session".to_string();
+        let replay_bytes = b"REPLAY-ME".to_vec();
+
+        let (client_tx, mut client_rx) = mpsc::channel::<Message>(32);
+        let (input_tx, _input_rx) = mpsc::unbounded_channel();
+        let (resize_tx, _resize_rx) = mpsc::unbounded_channel();
+
+        {
+            let mut st = state.write().await;
+            st.mobile_clients.insert(addr, client_tx);
+            st.mobile_views
+                .entry(addr)
+                .or_default()
+                .insert(session_id.clone());
+            st.session_view_counts.insert(session_id.clone(), 1);
+            st.pending_tui_replay
+                .entry(addr)
+                .or_default()
+                .insert(session_id.clone());
+
+            let mut scrollback = VecDeque::new();
+            scrollback.extend(replay_bytes.iter().copied());
+
+            let mut cli_tracker = CliTracker::new();
+            cli_tracker.update_from_command("codex");
+
+            st.sessions.insert(
+                session_id.clone(),
+                PtySession {
+                    session_id: session_id.clone(),
+                    name: "Codex".to_string(),
+                    command: "codex".to_string(),
+                    project_path: "/tmp".to_string(),
+                    started_at: Utc::now(),
+                    input_tx,
+                    resize_tx,
+                    waiting_state: None,
+                    cli_tracker,
+                    last_wait_hash: None,
+                    scrollback,
+                    scrollback_max_bytes: DEFAULT_SCROLLBACK_MAX_BYTES,
+                    in_alt_screen: false,
+                    alt_track_tail: Vec::new(),
+                    frame_cursor_pos_count: 0,
+                    frame_erase_line_count: 0,
+                    frame_render_mode: true,
+                    last_resize_epoch: 0,
+                    last_applied_size: Some((95, 27)),
+                },
+            );
+        }
+
+        broadcast_pty_resized(&state, &session_id, 95, 27, Some(1)).await;
+
+        let mut first_ack = 0usize;
+        let mut first_replay = Vec::new();
+        loop {
+            match timeout(Duration::from_millis(50), client_rx.recv()).await {
+                Ok(Some(Message::Text(text))) => {
+                    let msg: serde_json::Value =
+                        serde_json::from_str(text.as_ref()).expect("valid json");
+                    match msg.get("type").and_then(|t| t.as_str()) {
+                        Some("pty_resized") => first_ack += 1,
+                        Some("pty_bytes") => {
+                            let data = msg
+                                .get("data")
+                                .and_then(|d| d.as_str())
+                                .expect("pty bytes data");
+                            first_replay.push(
+                                base64::engine::general_purpose::STANDARD
+                                    .decode(data)
+                                    .expect("base64 decode"),
+                            );
+                        }
+                        _ => {}
+                    }
+                }
+                Ok(Some(_)) => {}
+                Ok(None) | Err(_) => break,
+            }
+        }
+
+        assert_eq!(first_ack, 1);
+        assert_eq!(first_replay.len(), 1);
+        assert_eq!(first_replay[0], replay_bytes);
+
+        {
+            let st = state.read().await;
+            assert!(!st
+                .pending_tui_replay
+                .get(&addr)
+                .map(|pending| pending.contains(&session_id))
+                .unwrap_or(false));
+        }
+
+        broadcast_pty_resized(&state, &session_id, 96, 27, Some(2)).await;
+
+        let mut second_ack = 0usize;
+        let mut second_replay = 0usize;
+        loop {
+            match timeout(Duration::from_millis(50), client_rx.recv()).await {
+                Ok(Some(Message::Text(text))) => {
+                    let msg: serde_json::Value =
+                        serde_json::from_str(text.as_ref()).expect("valid json");
+                    match msg.get("type").and_then(|t| t.as_str()) {
+                        Some("pty_resized") => second_ack += 1,
+                        Some("pty_bytes") => second_replay += 1,
+                        _ => {}
+                    }
+                }
+                Ok(Some(_)) => {}
+                Ok(None) | Err(_) => break,
+            }
+        }
+
+        assert_eq!(second_ack, 1);
+        assert_eq!(second_replay, 0);
     }
 }

--- a/cli/src/link.rs
+++ b/cli/src/link.rs
@@ -25,6 +25,7 @@ pub async fn run(session_id: Option<String>) -> Result<(), Box<dyn std::error::E
     // Send hello
     let hello = ClientMessage::Hello {
         client_version: env!("CARGO_PKG_VERSION").to_string(),
+        sender_id: None,
     };
     ws.send(Message::Text(serde_json::to_string(&hello)?))
         .await?;
@@ -172,6 +173,7 @@ async fn run_linked_mode(
     // Send hello
     let hello = ClientMessage::Hello {
         client_version: env!("CARGO_PKG_VERSION").to_string(),
+        sender_id: None,
     };
     tx.send(Message::Text(serde_json::to_string(&hello)?))
         .await?;

--- a/cli/src/link.rs
+++ b/cli/src/link.rs
@@ -26,6 +26,7 @@ pub async fn run(session_id: Option<String>) -> Result<(), Box<dyn std::error::E
     let hello = ClientMessage::Hello {
         client_version: env!("CARGO_PKG_VERSION").to_string(),
         sender_id: None,
+        client_capabilities: None,
     };
     ws.send(Message::Text(serde_json::to_string(&hello)?))
         .await?;
@@ -174,6 +175,7 @@ async fn run_linked_mode(
     let hello = ClientMessage::Hello {
         client_version: env!("CARGO_PKG_VERSION").to_string(),
         sender_id: None,
+        client_capabilities: None,
     };
     tx.send(Message::Text(serde_json::to_string(&hello)?))
         .await?;
@@ -181,6 +183,8 @@ async fn run_linked_mode(
     // Subscribe to session
     let subscribe = ClientMessage::Subscribe {
         session_id: session.session_id.clone(),
+        last_seen_seq: None,
+        client_capabilities: None,
     };
     tx.send(Message::Text(serde_json::to_string(&subscribe)?))
         .await?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -21,6 +21,7 @@ mod qr;
 mod session;
 mod setup;
 mod shell_hook;
+mod tmux;
 
 use clap::{Parser, Subcommand};
 use colored::Colorize;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -92,7 +92,8 @@ enum Commands {
         session: Option<String>,
     },
 
-    /// Manage auto-launch hook in your shell config (open mobilecli automatically in new terminals)
+    /// Manage shell auto-launch hook (open mobilecli automatically in new terminals)
+    #[command(name = "autolaunch", visible_alias = "shell-hook")]
     ShellHook {
         #[command(subcommand)]
         command: shell_hook::ShellHookCommand,

--- a/cli/src/protocol.rs
+++ b/cli/src/protocol.rs
@@ -41,9 +41,15 @@ pub enum ClientMessage {
         client_version: String,
         #[serde(default)]
         sender_id: Option<String>,
+        #[serde(default)]
+        client_capabilities: Option<u32>,
     },
     Subscribe {
         session_id: String,
+        #[serde(default)]
+        last_seen_seq: Option<u64>,
+        #[serde(default)]
+        client_capabilities: Option<u32>,
     },
     Unsubscribe {
         session_id: String,
@@ -262,6 +268,44 @@ pub enum ServerMessage {
         in_alt_screen: bool,
         #[serde(skip_serializing_if = "Option::is_none")]
         runtime: Option<String>,
+    },
+    /// Attach v2 start marker for deterministic replay/live handoff.
+    AttachBegin {
+        session_id: String,
+        attach_id: u64,
+        runtime: String,
+        mode: String, // "fresh" | "reconnect"
+        in_alt_screen: bool,
+    },
+    /// Attach v2 clear marker (client clears local terminal canvas/buffer).
+    AttachClear {
+        session_id: String,
+        attach_id: u64,
+    },
+    /// Attach v2 replay payload chunk.
+    AttachSnapshotChunk {
+        session_id: String,
+        attach_id: u64,
+        chunk_seq: u32,
+        total_chunks: u32,
+        is_last: bool,
+        data: String, // base64 encoded bytes
+    },
+    /// Attach v2 replay complete; live stream begins after this point.
+    AttachReady {
+        session_id: String,
+        attach_id: u64,
+        last_live_seq: u64,
+        cols: u16,
+        rows: u16,
+    },
+    /// Live PTY data tagged with attach + sequence for dedupe ordering.
+    PtyChunk {
+        session_id: String,
+        attach_id: u64,
+        seq: u64,
+        data: String, // base64 encoded bytes
+        timestamp_ms: u64,
     },
     /// PTY resized confirmation
     PtyResized {

--- a/cli/src/protocol.rs
+++ b/cli/src/protocol.rs
@@ -4,6 +4,35 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Semantic reason for a PTY resize request.
+///
+/// `Unknown` allows forward compatibility when newer clients introduce
+/// additional reasons.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PtyResizeReason {
+    AttachInit,
+    GeometryChange,
+    ReconnectSync,
+    DetachRestore,
+    KeyboardOverlay,
+    #[serde(other)]
+    Unknown,
+}
+
+impl PtyResizeReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::AttachInit => "attach_init",
+            Self::GeometryChange => "geometry_change",
+            Self::ReconnectSync => "reconnect_sync",
+            Self::DetachRestore => "detach_restore",
+            Self::KeyboardOverlay => "keyboard_overlay",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
 /// Messages sent from mobile client to server
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -32,6 +61,8 @@ pub enum ClientMessage {
         rows: u16,
         #[serde(default)]
         epoch: Option<u64>,
+        #[serde(default)]
+        reason: Option<PtyResizeReason>,
     },
     /// Heartbeat ping
     Ping,

--- a/cli/src/protocol.rs
+++ b/cli/src/protocol.rs
@@ -39,6 +39,8 @@ impl PtyResizeReason {
 pub enum ClientMessage {
     Hello {
         client_version: String,
+        #[serde(default)]
+        sender_id: Option<String>,
     },
     Subscribe {
         session_id: String,

--- a/cli/src/protocol.rs
+++ b/cli/src/protocol.rs
@@ -377,6 +377,9 @@ pub struct SessionListItem {
     pub started_at: String,
     /// Explicit CLI type identifier for mobile app disambiguation
     pub cli_type: String,
+    /// Runtime backend for this session (`pty` or `tmux`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/cli/src/protocol.rs
+++ b/cli/src/protocol.rs
@@ -258,6 +258,8 @@ pub enum ServerMessage {
     SubscribeAck {
         session_id: String,
         in_alt_screen: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        runtime: Option<String>,
     },
     /// PTY resized confirmation
     PtyResized {

--- a/cli/src/pty_wrapper.rs
+++ b/cli/src/pty_wrapper.rs
@@ -348,7 +348,12 @@ fn setup_tmux_session(
     let option_sets: [(&str, &str, &str, &str); 4] = [
         ("set-option", session_name, "status", "off"),
         ("set-option", session_name, "allow-rename", "off"),
-        ("set-window-option", &window_target, "alternate-screen", "off"),
+        (
+            "set-window-option",
+            &window_target,
+            "alternate-screen",
+            "off",
+        ),
         ("set-window-option", &window_target, "window-size", "latest"),
     ];
     for (command, target, key, value) in option_sets {

--- a/cli/src/pty_wrapper.rs
+++ b/cli/src/pty_wrapper.rs
@@ -15,6 +15,7 @@ use futures_util::{SinkExt, StreamExt};
 use portable_pty::{native_pty_system, CommandBuilder, PtySize};
 use std::borrow::Cow;
 use std::io::{IsTerminal, Read, Write};
+use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use thiserror::Error;
@@ -40,6 +41,27 @@ pub struct WrapConfig {
     pub session_name: String,
     pub quiet: bool,
     pub working_dir: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RuntimeMode {
+    Pty,
+    Tmux,
+}
+
+impl RuntimeMode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Pty => "pty",
+            Self::Tmux => "tmux",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TmuxContext {
+    socket_name: String,
+    session_name: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -133,33 +155,168 @@ fn request_terminal_resize(cols: u16, rows: u16) {
     set_stdout_winsize(cols, rows);
 }
 
-fn clear_local_terminal_view(stdout: &mut std::io::Stdout) {
-    if !stdout.is_terminal() {
-        return;
-    }
-    let _ = stdout.write_all(b"\x1b[2J\x1b[H");
-    let _ = stdout.flush();
+fn tmux_base_command(socket_name: &str) -> Command {
+    let mut cmd = Command::new("tmux");
+    cmd.arg("-L")
+        .arg(socket_name)
+        .arg("-f")
+        .arg("/dev/null")
+        .env_remove("TMUX");
+    cmd
 }
 
-fn should_clear_local_before_resize(
-    reason: PtyResizeReason,
-    previous: Option<(u16, u16)>,
-    cols: u16,
-) -> bool {
-    match reason {
-        PtyResizeReason::DetachRestore => true,
-        PtyResizeReason::GeometryChange => previous.is_some_and(|(prev_cols, _)| prev_cols != cols),
-        PtyResizeReason::AttachInit
-        | PtyResizeReason::ReconnectSync
-        | PtyResizeReason::KeyboardOverlay
-        | PtyResizeReason::Unknown => false,
+fn run_tmux_checked(cmd: &mut Command, context: &str) -> Result<(), WrapError> {
+    let output = cmd
+        .output()
+        .map_err(|e| WrapError::Pty(format!("Failed to run tmux ({context}): {e}")))?;
+    if output.status.success() {
+        return Ok(());
     }
+
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let detail = if !stderr.is_empty() {
+        stderr
+    } else if !stdout.is_empty() {
+        stdout
+    } else {
+        format!("exit status {}", output.status)
+    };
+    Err(WrapError::Pty(format!(
+        "tmux command failed ({context}): {detail}"
+    )))
 }
 
 fn jitter_resize_target(cols: u16, rows: u16) -> (u16, u16) {
     let jitter_cols = if cols > 1 { cols - 1 } else { cols + 1 };
     let jitter_rows = if rows > 1 { rows - 1 } else { rows + 1 };
     (jitter_cols, jitter_rows)
+}
+
+fn sanitize_tmux_token(raw: &str) -> String {
+    let mut out: String = raw
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    if out.is_empty() {
+        out.push_str("session");
+    }
+    out
+}
+
+fn resolve_runtime_mode() -> RuntimeMode {
+    let requested = std::env::var("MOBILECLI_RUNTIME")
+        .unwrap_or_else(|_| "auto".to_string())
+        .to_lowercase();
+
+    match requested.as_str() {
+        "pty" | "legacy" => RuntimeMode::Pty,
+        "tmux" => {
+            if which::which("tmux").is_ok() {
+                RuntimeMode::Tmux
+            } else {
+                tracing::warn!(
+                    "MOBILECLI_RUNTIME=tmux requested, but tmux is not installed; falling back to pty runtime"
+                );
+                RuntimeMode::Pty
+            }
+        }
+        // Default auto policy prefers tmux when available because frame-rendered
+        // TUIs (Codex/OpenCode/etc.) need multiplexer semantics for reliable reattach.
+        "auto" | "" => {
+            if which::which("tmux").is_ok() {
+                RuntimeMode::Tmux
+            } else {
+                RuntimeMode::Pty
+            }
+        }
+        other => {
+            tracing::warn!(
+                "Unknown MOBILECLI_RUNTIME='{}'. Falling back to auto policy.",
+                other
+            );
+            if which::which("tmux").is_ok() {
+                RuntimeMode::Tmux
+            } else {
+                RuntimeMode::Pty
+            }
+        }
+    }
+}
+
+fn setup_tmux_session(
+    socket_name: &str,
+    session_name: &str,
+    command_path: &str,
+    args: &[String],
+    cwd: &str,
+    cols: u16,
+    rows: u16,
+) -> Result<(), WrapError> {
+    let mut new_session = tmux_base_command(socket_name);
+    new_session
+        .arg("new-session")
+        .arg("-d")
+        .arg("-s")
+        .arg(session_name)
+        .arg("-x")
+        .arg(cols.to_string())
+        .arg("-y")
+        .arg(rows.to_string())
+        .arg("--")
+        .arg(command_path)
+        .args(args)
+        .current_dir(cwd)
+        .env("TERM", "xterm-256color")
+        .env("MOBILECLI_SESSION", "1");
+    run_tmux_checked(&mut new_session, "new-session")?;
+
+    // Best-effort options for deterministic rendering behavior.
+    let window_target = format!("{}:0", session_name);
+    let option_sets: [(&str, &str, &str, &str); 4] = [
+        ("set-option", session_name, "status", "off"),
+        ("set-option", session_name, "allow-rename", "off"),
+        ("set-option", session_name, "history-limit", "200000"),
+        ("set-window-option", &window_target, "window-size", "manual"),
+    ];
+    for (command, target, key, value) in option_sets {
+        let mut option_cmd = tmux_base_command(socket_name);
+        option_cmd
+            .arg(command)
+            .arg("-t")
+            .arg(target)
+            .arg(key)
+            .arg(value);
+        if let Err(err) = run_tmux_checked(&mut option_cmd, key) {
+            tracing::debug!(
+                socket = socket_name,
+                session = session_name,
+                option = key,
+                error = %err,
+                "Ignoring non-fatal tmux option failure"
+            );
+        }
+    }
+    Ok(())
+}
+
+fn cleanup_tmux_session(ctx: &TmuxContext) {
+    let mut cmd = tmux_base_command(&ctx.socket_name);
+    cmd.arg("kill-server");
+    if let Err(err) = run_tmux_checked(&mut cmd, "kill-server") {
+        tracing::debug!(
+            socket = %ctx.socket_name,
+            session = %ctx.session_name,
+            error = %err,
+            "Best-effort tmux cleanup failed"
+        );
+    }
 }
 
 fn resolve_resize_reason(cols: u16, rows: u16, reason: Option<&str>) -> PtyResizeReason {
@@ -219,6 +376,7 @@ pub async fn run_wrapped(config: WrapConfig) -> Result<i32, WrapError> {
     // Resolve the command path
     let cmd_path = resolve_command(&config.command)
         .ok_or_else(|| WrapError::CommandNotFound(config.command.clone()))?;
+    let runtime_mode = resolve_runtime_mode();
 
     // Generate session ID (12 chars for better collision resistance)
     let session_id = uuid::Uuid::new_v4().to_string()[..12].to_string();
@@ -246,6 +404,7 @@ pub async fn run_wrapped(config: WrapConfig) -> Result<i32, WrapError> {
         "name": config.session_name,
         "command": config.command,
         "project_path": cwd,
+        "runtime": runtime_mode.as_str(),
     });
     ws_tx
         .send(Message::Text(register_msg.to_string()))
@@ -265,14 +424,15 @@ pub async fn run_wrapped(config: WrapConfig) -> Result<i32, WrapError> {
 
     if !config.quiet {
         println!(
-            "{} {} {}",
+            "{} {} {} {}",
             "📱".green(),
             "Connected!".green().bold(),
             format!(
                 "Session '{}' is now visible on your phone",
                 config.session_name
             )
-            .dimmed()
+            .dimmed(),
+            format!("[runtime:{}]", runtime_mode.as_str()).dimmed()
         );
     }
 
@@ -289,9 +449,43 @@ pub async fn run_wrapped(config: WrapConfig) -> Result<i32, WrapError> {
         })
         .map_err(|e| WrapError::Pty(e.to_string()))?;
 
+    let mut tmux_context: Option<TmuxContext> = None;
+    if runtime_mode == RuntimeMode::Tmux {
+        let token = sanitize_tmux_token(&session_id);
+        let ctx = TmuxContext {
+            socket_name: format!("mcli-{}", token),
+            session_name: format!("mcli-{}", token),
+        };
+        setup_tmux_session(
+            &ctx.socket_name,
+            &ctx.session_name,
+            &cmd_path,
+            &config.args,
+            &cwd,
+            cols,
+            rows,
+        )?;
+        tmux_context = Some(ctx);
+    }
+
     // Build command
-    let mut cmd = CommandBuilder::new(&cmd_path);
-    cmd.args(&config.args);
+    let mut cmd = if let Some(ctx) = &tmux_context {
+        let mut c = CommandBuilder::new("tmux");
+        c.args([
+            "-L",
+            ctx.socket_name.as_str(),
+            "-f",
+            "/dev/null",
+            "attach-session",
+            "-t",
+            ctx.session_name.as_str(),
+        ]);
+        c
+    } else {
+        let mut c = CommandBuilder::new(&cmd_path);
+        c.args(&config.args);
+        c
+    };
     cmd.cwd(&cwd);
 
     // Set up environment for interactive shell
@@ -304,10 +498,12 @@ pub async fn run_wrapped(config: WrapConfig) -> Result<i32, WrapError> {
     cmd.env("MOBILECLI_SESSION", "1");
 
     // Spawn the command
-    let mut child = pair
-        .slave
-        .spawn_command(cmd)
-        .map_err(|e| WrapError::Pty(e.to_string()))?;
+    let mut child = pair.slave.spawn_command(cmd).map_err(|e| {
+        if let Some(ctx) = &tmux_context {
+            cleanup_tmux_session(ctx);
+        }
+        WrapError::Pty(e.to_string())
+    })?;
 
     // Drop the slave - we communicate through the master
     drop(pair.slave);
@@ -515,18 +711,6 @@ pub async fn run_wrapped(config: WrapConfig) -> Result<i32, WrapError> {
                                             PtyResizeReason::AttachInit | PtyResizeReason::ReconnectSync
                                         ) && last_applied_pty_size == Some((c, r));
 
-                                        if should_clear_local_before_resize(reason, last_applied_pty_size, c) {
-                                            tracing::debug!(
-                                                session_id = %session_id,
-                                                cols = c,
-                                                rows = r,
-                                                epoch = ?epoch,
-                                                reason = reason.as_str(),
-                                                "Clearing local terminal before semantic resize"
-                                            );
-                                            clear_local_terminal_view(&mut stdout);
-                                        }
-
                                         let should_resize =
                                             force_noop_refresh || last_applied_pty_size != Some((c, r));
                                         if should_resize {
@@ -651,6 +835,10 @@ pub async fn run_wrapped(config: WrapConfig) -> Result<i32, WrapError> {
     // Wait for reader thread
     let _ = reader_handle.join();
 
+    if let Some(ctx) = &tmux_context {
+        cleanup_tmux_session(ctx);
+    }
+
     // Print exit message
     println!();
     if exit_code == 0 {
@@ -709,7 +897,8 @@ fn restore_terminal_mode(_original: Option<()>) {}
 #[cfg(test)]
 mod tests {
     use super::{
-        jitter_resize_target, resolve_resize_reason, should_clear_local_before_resize,
+        cleanup_tmux_session, jitter_resize_target, resolve_resize_reason, resolve_runtime_mode,
+        sanitize_tmux_token, setup_tmux_session, tmux_base_command, RuntimeMode, TmuxContext,
     };
     use crate::protocol::PtyResizeReason;
 
@@ -742,42 +931,73 @@ mod tests {
     }
 
     #[test]
-    fn clear_policy_prefers_detach_and_width_changes_only() {
-        assert!(!should_clear_local_before_resize(
-            PtyResizeReason::AttachInit,
-            Some((80, 24)),
-            80
-        ));
-        assert!(!should_clear_local_before_resize(
-            PtyResizeReason::ReconnectSync,
-            Some((80, 24)),
-            80
-        ));
-        assert!(should_clear_local_before_resize(
-            PtyResizeReason::DetachRestore,
-            Some((80, 24)),
-            120
-        ));
-        assert!(should_clear_local_before_resize(
-            PtyResizeReason::GeometryChange,
-            Some((80, 24)),
-            100
-        ));
-        assert!(!should_clear_local_before_resize(
-            PtyResizeReason::GeometryChange,
-            Some((80, 24)),
-            80
-        ));
-        assert!(!should_clear_local_before_resize(
-            PtyResizeReason::KeyboardOverlay,
-            Some((80, 24)),
-            80
-        ));
+    fn tmux_token_sanitizes_non_identifier_chars() {
+        assert_eq!(sanitize_tmux_token("abc123"), "abc123");
+        assert_eq!(sanitize_tmux_token("abc/def"), "abc-def");
+        assert_eq!(sanitize_tmux_token(""), "session");
     }
 
     #[test]
     fn jitter_target_always_changes_dimensions() {
         assert_eq!(jitter_resize_target(80, 24), (79, 23));
         assert_eq!(jitter_resize_target(1, 1), (2, 2));
+    }
+
+    #[test]
+    fn runtime_mode_honors_explicit_pty_override() {
+        std::env::set_var("MOBILECLI_RUNTIME", "pty");
+        assert_eq!(resolve_runtime_mode(), RuntimeMode::Pty);
+        std::env::remove_var("MOBILECLI_RUNTIME");
+    }
+
+    #[test]
+    fn tmux_session_bootstrap_and_cleanup_roundtrip() {
+        if which::which("tmux").is_err() {
+            return;
+        }
+
+        let token = sanitize_tmux_token(&uuid::Uuid::new_v4().to_string()[..12]);
+        let ctx = TmuxContext {
+            socket_name: format!("mcli-test-{}", token),
+            session_name: format!("mcli-test-{}", token),
+        };
+
+        setup_tmux_session(
+            &ctx.socket_name,
+            &ctx.session_name,
+            "/bin/sh",
+            &vec!["-lc".to_string(), "printf tmux-test".to_string()],
+            ".",
+            80,
+            24,
+        )
+        .expect("setup tmux session");
+
+        let mut has_session = tmux_base_command(&ctx.socket_name);
+        let output = has_session
+            .arg("has-session")
+            .arg("-t")
+            .arg(&ctx.session_name)
+            .output()
+            .expect("has-session output");
+        assert!(
+            output.status.success(),
+            "expected has-session success: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        cleanup_tmux_session(&ctx);
+
+        let mut has_after_cleanup = tmux_base_command(&ctx.socket_name);
+        let output = has_after_cleanup
+            .arg("has-session")
+            .arg("-t")
+            .arg(&ctx.session_name)
+            .output()
+            .expect("has-session output");
+        assert!(
+            !output.status.success(),
+            "expected tmux session cleanup to remove server/session"
+        );
     }
 }

--- a/cli/src/pty_wrapper.rs
+++ b/cli/src/pty_wrapper.rs
@@ -188,12 +188,6 @@ fn run_tmux_checked(cmd: &mut Command, context: &str) -> Result<(), WrapError> {
     )))
 }
 
-fn jitter_resize_target(cols: u16, rows: u16) -> (u16, u16) {
-    let jitter_cols = if cols > 1 { cols - 1 } else { cols + 1 };
-    let jitter_rows = if rows > 1 { rows - 1 } else { rows + 1 };
-    (jitter_cols, jitter_rows)
-}
-
 fn resolve_runtime_mode() -> RuntimeMode {
     let requested = std::env::var("MOBILECLI_RUNTIME")
         .unwrap_or_else(|_| "auto".to_string())
@@ -762,38 +756,8 @@ pub async fn run_wrapped(config: WrapConfig) -> Result<i32, WrapError> {
                                             }
                                         }
 
-                                        let force_noop_refresh = runtime_mode == RuntimeMode::Pty
-                                            && matches!(
-                                                reason,
-                                                PtyResizeReason::AttachInit
-                                                    | PtyResizeReason::ReconnectSync
-                                            )
-                                            && last_applied_pty_size == Some((c, r));
-
-                                        let should_resize =
-                                            force_noop_refresh || last_applied_pty_size != Some((c, r));
+                                        let should_resize = last_applied_pty_size != Some((c, r));
                                         if should_resize {
-                                            if force_noop_refresh {
-                                                let (jitter_c, jitter_r) = jitter_resize_target(c, r);
-                                                tracing::debug!(
-                                                    session_id = %session_id,
-                                                    cols = c,
-                                                    rows = r,
-                                                    jitter_cols = jitter_c,
-                                                    jitter_rows = jitter_r,
-                                                    epoch = ?epoch,
-                                                    reason = reason.as_str(),
-                                                    decision = "force_noop_redraw",
-                                                    "Applying jitter resize before final target to force redraw"
-                                                );
-                                                let _ = master.resize(PtySize {
-                                                    rows: jitter_r,
-                                                    cols: jitter_c,
-                                                    pixel_width: 0,
-                                                    pixel_height: 0,
-                                                });
-                                            }
-
                                             let resized = master.resize(PtySize {
                                                 rows: r,
                                                 cols: c,
@@ -956,8 +920,8 @@ fn restore_terminal_mode(_original: Option<()>) {}
 #[cfg(test)]
 mod tests {
     use super::{
-        cleanup_tmux_session, jitter_resize_target, resolve_resize_reason, resolve_runtime_mode,
-        sanitize_tmux_token, setup_tmux_session, tmux_base_command, RuntimeMode, TmuxContext,
+        cleanup_tmux_session, resolve_resize_reason, resolve_runtime_mode, sanitize_tmux_token,
+        setup_tmux_session, tmux_base_command, RuntimeMode, TmuxContext,
     };
     use crate::protocol::PtyResizeReason;
 
@@ -998,12 +962,6 @@ mod tests {
         assert_eq!(sanitize_tmux_token("abc123"), "abc123");
         assert_eq!(sanitize_tmux_token("abc/def"), "abc-def");
         assert_eq!(sanitize_tmux_token(""), "session");
-    }
-
-    #[test]
-    fn jitter_target_always_changes_dimensions() {
-        assert_eq!(jitter_resize_target(80, 24), (79, 23));
-        assert_eq!(jitter_resize_target(1, 1), (2, 2));
     }
 
     #[test]

--- a/cli/src/pty_wrapper.rs
+++ b/cli/src/pty_wrapper.rs
@@ -968,7 +968,8 @@ mod tests {
             &ctx.socket_name,
             &ctx.session_name,
             "/bin/sh",
-            &vec!["-lc".to_string(), "sleep 3".to_string()],
+            // Keep the session alive long enough for CI has-session checks.
+            &vec!["-lc".to_string(), "sleep 10 & wait".to_string()],
             ".",
             80,
             24,

--- a/cli/src/pty_wrapper.rs
+++ b/cli/src/pty_wrapper.rs
@@ -354,7 +354,7 @@ fn resolve_resize_reason(cols: u16, rows: u16, reason: Option<&str>) -> PtyResiz
         Some("geometry_change") => PtyResizeReason::GeometryChange,
         Some("reconnect_sync") => PtyResizeReason::ReconnectSync,
         Some("keyboard_overlay") => PtyResizeReason::KeyboardOverlay,
-        Some("detach_restore") => PtyResizeReason::GeometryChange,
+        Some("detach_restore") => PtyResizeReason::DetachRestore,
         _ => PtyResizeReason::GeometryChange,
     }
 }
@@ -732,10 +732,13 @@ pub async fn run_wrapped(config: WrapConfig) -> Result<i32, WrapError> {
                                             }
                                         }
 
-                                        let force_noop_refresh = matches!(
-                                            reason,
-                                            PtyResizeReason::AttachInit | PtyResizeReason::ReconnectSync
-                                        ) && last_applied_pty_size == Some((c, r));
+                                        let force_noop_refresh = runtime_mode == RuntimeMode::Pty
+                                            && matches!(
+                                                reason,
+                                                PtyResizeReason::AttachInit
+                                                    | PtyResizeReason::ReconnectSync
+                                            )
+                                            && last_applied_pty_size == Some((c, r));
 
                                         let should_resize =
                                             force_noop_refresh || last_applied_pty_size != Some((c, r));
@@ -949,6 +952,10 @@ mod tests {
         assert_eq!(
             resolve_resize_reason(80, 24, Some("keyboard_overlay")),
             PtyResizeReason::KeyboardOverlay
+        );
+        assert_eq!(
+            resolve_resize_reason(80, 24, Some("detach_restore")),
+            PtyResizeReason::DetachRestore
         );
         assert_eq!(
             resolve_resize_reason(80, 24, Some("future_reason")),

--- a/cli/src/pty_wrapper.rs
+++ b/cli/src/pty_wrapper.rs
@@ -699,8 +699,8 @@ pub async fn run_wrapped(config: WrapConfig) -> Result<i32, WrapError> {
 
                                         if reason == PtyResizeReason::DetachRestore {
                                             // Mobile detached. Restore PTY dimensions to the host
-                                            // terminal's current size. In mirror mode, also
-                                            // restore the host window to the original size.
+                                            // terminal's pre-mobile size when available. In mirror
+                                            // mode, also restore the host window.
                                             let (restore_c, restore_r) = match desktop_resize_policy {
                                                 DesktopResizePolicy::Mirror => {
                                                     if let Some((lc, lr)) = saved_local_size.take() {
@@ -711,8 +711,11 @@ pub async fn run_wrapped(config: WrapConfig) -> Result<i32, WrapError> {
                                                     }
                                                 }
                                                 DesktopResizePolicy::Preserve => {
-                                                    saved_local_size = None;
-                                                    get_terminal_size()
+                                                    if let Some((lc, lr)) = saved_local_size.take() {
+                                                        (lc, lr)
+                                                    } else {
+                                                        get_terminal_size()
+                                                    }
                                                 }
                                             };
                                             c = restore_c;
@@ -721,9 +724,7 @@ pub async fn run_wrapped(config: WrapConfig) -> Result<i32, WrapError> {
                                             // Mobile active: always resize child PTY to mobile
                                             // dimensions. Host terminal mirroring is opt-in via
                                             // MOBILECLI_DESKTOP_RESIZE_POLICY=mirror.
-                                            if desktop_resize_policy == DesktopResizePolicy::Mirror
-                                                && saved_local_size.is_none()
-                                            {
+                                            if saved_local_size.is_none() {
                                                 saved_local_size = get_terminal_size_opt();
                                             }
                                             if desktop_resize_policy == DesktopResizePolicy::Mirror {

--- a/cli/src/pty_wrapper.rs
+++ b/cli/src/pty_wrapper.rs
@@ -147,11 +147,12 @@ fn should_clear_local_before_resize(
     cols: u16,
 ) -> bool {
     match reason {
+        PtyResizeReason::DetachRestore => true,
+        PtyResizeReason::GeometryChange => previous.is_some_and(|(prev_cols, _)| prev_cols != cols),
         PtyResizeReason::AttachInit
         | PtyResizeReason::ReconnectSync
-        | PtyResizeReason::DetachRestore => true,
-        PtyResizeReason::GeometryChange => previous.is_some_and(|(prev_cols, _)| prev_cols != cols),
-        PtyResizeReason::KeyboardOverlay | PtyResizeReason::Unknown => false,
+        | PtyResizeReason::KeyboardOverlay
+        | PtyResizeReason::Unknown => false,
     }
 }
 
@@ -741,13 +742,13 @@ mod tests {
     }
 
     #[test]
-    fn clear_policy_prefers_attach_detach_and_width_changes() {
-        assert!(should_clear_local_before_resize(
+    fn clear_policy_prefers_detach_and_width_changes_only() {
+        assert!(!should_clear_local_before_resize(
             PtyResizeReason::AttachInit,
             Some((80, 24)),
             80
         ));
-        assert!(should_clear_local_before_resize(
+        assert!(!should_clear_local_before_resize(
             PtyResizeReason::ReconnectSync,
             Some((80, 24)),
             80

--- a/cli/src/pty_wrapper.rs
+++ b/cli/src/pty_wrapper.rs
@@ -260,8 +260,12 @@ fn setup_tmux_session(
     rows: u16,
 ) -> Result<(), WrapError> {
     // Bootstrap a dedicated tmux server first so global options apply before
-    // the wrapped CLI starts. This avoids races where frame CLIs enter
-    // alternate-screen at launch and drop scrollback history.
+    // the wrapped CLI starts. We also disable alternate-screen globally here
+    // because the pty_wrapper runs tmux attach-session inside the host
+    // terminal (e.g. Konsole). If alternate-screen is enabled, tmux forwards
+    // \x1b[?1049h to the host terminal when TUI apps run, causing the host to
+    // enter its own alt-screen and lose its scrollback. Disabling it keeps
+    // all output in the main buffer where capture-pane can reach it.
     let mut start_server = tmux_base_command(socket_name);
     start_server.arg("start-server");
     let _ = run_tmux_checked(&mut start_server, "start-server");
@@ -278,6 +282,25 @@ fn setup_tmux_session(
             session = session_name,
             error = %err,
             "Ignoring non-fatal pre-session alternate-screen option failure"
+        );
+    }
+
+    // Set history-limit globally BEFORE creating the session. tmux allocates
+    // each pane's history buffer at window-creation time using the current
+    // history-limit value; setting it after new-session has no effect on the
+    // window that was already created with the default 2000 lines.
+    let mut pre_history = tmux_base_command(socket_name);
+    pre_history
+        .arg("set-option")
+        .arg("-g")
+        .arg("history-limit")
+        .arg("200000");
+    if let Err(err) = run_tmux_checked(&mut pre_history, "history-limit") {
+        tracing::debug!(
+            socket = socket_name,
+            session = session_name,
+            error = %err,
+            "Ignoring non-fatal pre-session history-limit option failure"
         );
     }
 
@@ -303,10 +326,28 @@ fn setup_tmux_session(
     // NOTE: window-size must remain dynamic so wrapper PTY resizes propagate
     // into tmux panes when mobile dimensions change.
     let window_target = format!("{}:0", session_name);
-    let option_sets: [(&str, &str, &str, &str); 5] = [
+    // Disable smcup/rmcup so tmux itself does NOT enter Konsole's alternate
+    // screen on attach. Without this, Konsole has zero scrollback while tmux
+    // is attached (alt-screen has no history buffer). With it disabled, tmux
+    // renders in Konsole's main buffer and the scrollbar works.
+    let mut disable_altscreen_client = tmux_base_command(socket_name);
+    disable_altscreen_client
+        .arg("set-option")
+        .arg("-g")
+        .arg("terminal-overrides")
+        .arg("xterm*:smcup@:rmcup@");
+    let _ = run_tmux_checked(&mut disable_altscreen_client, "terminal-overrides");
+
+    // Enable mouse so scroll wheel works with tmux's history buffer.
+    let mut mouse_on = tmux_base_command(socket_name);
+    mouse_on.arg("set-option").arg("-g").arg("mouse").arg("on");
+    let _ = run_tmux_checked(&mut mouse_on, "mouse");
+
+    // history-limit is set globally before new-session so the window is
+    // allocated with the full 200K-line buffer from the start.
+    let option_sets: [(&str, &str, &str, &str); 4] = [
         ("set-option", session_name, "status", "off"),
         ("set-option", session_name, "allow-rename", "off"),
-        ("set-option", session_name, "history-limit", "200000"),
         ("set-window-option", &window_target, "alternate-screen", "off"),
         ("set-window-option", &window_target, "window-size", "latest"),
     ];
@@ -1057,7 +1098,7 @@ mod tests {
         let alt_screen_mode = String::from_utf8_lossy(&output.stdout).trim().to_string();
         assert_eq!(
             alt_screen_mode, "off",
-            "expected tmux alternate-screen to be disabled so scrollback is preserved"
+            "expected tmux alternate-screen to be disabled to protect host terminal scrollback"
         );
 
         cleanup_tmux_session(&ctx);

--- a/cli/src/pty_wrapper.rs
+++ b/cli/src/pty_wrapper.rs
@@ -9,6 +9,7 @@
 
 use crate::daemon::{get_port, DEFAULT_PORT};
 use crate::protocol::PtyResizeReason;
+use crate::tmux::sanitize_tmux_token;
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use colored::Colorize;
 use futures_util::{SinkExt, StreamExt};
@@ -191,23 +192,6 @@ fn jitter_resize_target(cols: u16, rows: u16) -> (u16, u16) {
     let jitter_cols = if cols > 1 { cols - 1 } else { cols + 1 };
     let jitter_rows = if rows > 1 { rows - 1 } else { rows + 1 };
     (jitter_cols, jitter_rows)
-}
-
-fn sanitize_tmux_token(raw: &str) -> String {
-    let mut out: String = raw
-        .chars()
-        .map(|ch| {
-            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
-                ch
-            } else {
-                '-'
-            }
-        })
-        .collect();
-    if out.is_empty() {
-        out.push_str("session");
-    }
-    out
 }
 
 fn resolve_runtime_mode() -> RuntimeMode {

--- a/cli/src/pty_wrapper.rs
+++ b/cli/src/pty_wrapper.rs
@@ -8,6 +8,7 @@
 //! 5. Handles terminal resize events
 
 use crate::daemon::{get_port, DEFAULT_PORT};
+use crate::protocol::PtyResizeReason;
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use colored::Colorize;
 use futures_util::{SinkExt, StreamExt};
@@ -130,6 +131,21 @@ fn request_terminal_resize(cols: u16, rows: u16) {
     let _ = stdout.write_all(seq.as_bytes());
     let _ = stdout.flush();
     set_stdout_winsize(cols, rows);
+}
+
+fn resolve_resize_reason(cols: u16, rows: u16, reason: Option<&str>) -> PtyResizeReason {
+    if cols == 0 || rows == 0 {
+        return PtyResizeReason::DetachRestore;
+    }
+
+    match reason {
+        Some("attach_init") => PtyResizeReason::AttachInit,
+        Some("geometry_change") => PtyResizeReason::GeometryChange,
+        Some("reconnect_sync") => PtyResizeReason::ReconnectSync,
+        Some("keyboard_overlay") => PtyResizeReason::KeyboardOverlay,
+        Some("detach_restore") => PtyResizeReason::GeometryChange,
+        _ => PtyResizeReason::GeometryChange,
+    }
 }
 
 /// Normalize newline input sequences before writing into the PTY.
@@ -340,6 +356,7 @@ pub async fn run_wrapped(config: WrapConfig) -> Result<i32, WrapError> {
     let mut stdout = std::io::stdout();
     let desktop_resize_policy = DesktopResizePolicy::from_env();
     let mut saved_local_size: Option<(u16, u16)> = None;
+    let mut last_applied_pty_size: Option<(u16, u16)> = Some((cols, rows));
     let mut exit_code: i32 = 0;
 
     loop {
@@ -391,12 +408,50 @@ pub async fn run_wrapped(config: WrapConfig) -> Result<i32, WrapError> {
                                         msg["cols"].as_u64(),
                                         msg["rows"].as_u64(),
                                     ) {
+                                        let mut c = cols.min(u16::MAX as u64) as u16;
+                                        let mut r = rows.min(u16::MAX as u64) as u16;
                                         let epoch = msg["epoch"].as_u64();
-                                        if cols == 0 || rows == 0 {
-                                            // Mobile detached. Restore PTY dimensions to the
-                                            // host terminal's current size. In mirror mode,
-                                            // also restore the host window to the original size.
-                                            let (c, r) = match desktop_resize_policy {
+                                        let reason =
+                                            resolve_resize_reason(c, r, msg["reason"].as_str());
+                                        tracing::debug!(
+                                            session_id = %session_id,
+                                            cols = c,
+                                            rows = r,
+                                            epoch = ?epoch,
+                                            reason = reason.as_str(),
+                                            policy = ?desktop_resize_policy,
+                                            "Wrapper resize request"
+                                        );
+
+                                        if reason == PtyResizeReason::KeyboardOverlay {
+                                            let (ack_c, ack_r) = last_applied_pty_size.unwrap_or((c, r));
+                                            tracing::debug!(
+                                                session_id = %session_id,
+                                                cols = c,
+                                                rows = r,
+                                                epoch = ?epoch,
+                                                reason = reason.as_str(),
+                                                decision = "ignored_keyboard_overlay",
+                                                "Ignoring keyboard-only resize in wrapper"
+                                            );
+
+                                            let mut resized_msg = serde_json::json!({
+                                                "type": "pty_resized",
+                                                "cols": ack_c,
+                                                "rows": ack_r,
+                                            });
+                                            if let Some(epoch) = epoch {
+                                                resized_msg["epoch"] = serde_json::json!(epoch);
+                                            }
+                                            let _ = ws_tx.send(Message::Text(resized_msg.to_string())).await;
+                                            continue;
+                                        }
+
+                                        if reason == PtyResizeReason::DetachRestore {
+                                            // Mobile detached. Restore PTY dimensions to the host
+                                            // terminal's current size. In mirror mode, also
+                                            // restore the host window to the original size.
+                                            let (restore_c, restore_r) = match desktop_resize_policy {
                                                 DesktopResizePolicy::Mirror => {
                                                     if let Some((lc, lr)) = saved_local_size.take() {
                                                         request_terminal_resize(lc, lr);
@@ -410,22 +465,8 @@ pub async fn run_wrapped(config: WrapConfig) -> Result<i32, WrapError> {
                                                     get_terminal_size()
                                                 }
                                             };
-
-                                            let resized = master.resize(PtySize {
-                                                rows: r, cols: c,
-                                                pixel_width: 0, pixel_height: 0,
-                                            });
-                                            if resized.is_ok() {
-                                                let mut resized_msg = serde_json::json!({
-                                                    "type": "pty_resized",
-                                                    "cols": c,
-                                                    "rows": r,
-                                                });
-                                                if let Some(epoch) = epoch {
-                                                    resized_msg["epoch"] = serde_json::json!(epoch);
-                                                }
-                                                let _ = ws_tx.send(Message::Text(resized_msg.to_string())).await;
-                                            }
+                                            c = restore_c;
+                                            r = restore_r;
                                         } else {
                                             // Mobile active: always resize child PTY to mobile
                                             // dimensions. Host terminal mirroring is opt-in via
@@ -435,28 +476,63 @@ pub async fn run_wrapped(config: WrapConfig) -> Result<i32, WrapError> {
                                             {
                                                 saved_local_size = get_terminal_size_opt();
                                             }
-                                            let c = cols.min(u16::MAX as u64) as u16;
-                                            let r = rows.min(u16::MAX as u64) as u16;
                                             if desktop_resize_policy == DesktopResizePolicy::Mirror {
                                                 request_terminal_resize(c, r);
                                             }
+                                        }
 
+                                        let should_resize = last_applied_pty_size != Some((c, r));
+                                        if should_resize {
                                             let resized = master.resize(PtySize {
-                                                rows: r, cols: c,
-                                                pixel_width: 0, pixel_height: 0,
+                                                rows: r,
+                                                cols: c,
+                                                pixel_width: 0,
+                                                pixel_height: 0,
                                             });
                                             if resized.is_ok() {
-                                                let mut resized_msg = serde_json::json!({
-                                                    "type": "pty_resized",
-                                                    "cols": c,
-                                                    "rows": r,
-                                                });
-                                                if let Some(epoch) = epoch {
-                                                    resized_msg["epoch"] = serde_json::json!(epoch);
-                                                }
-                                                let _ = ws_tx.send(Message::Text(resized_msg.to_string())).await;
+                                                last_applied_pty_size = Some((c, r));
+                                                tracing::debug!(
+                                                    session_id = %session_id,
+                                                    cols = c,
+                                                    rows = r,
+                                                    epoch = ?epoch,
+                                                    reason = reason.as_str(),
+                                                    decision = "applied",
+                                                    "Applied PTY resize"
+                                                );
+                                            } else {
+                                                tracing::warn!(
+                                                    session_id = %session_id,
+                                                    cols = c,
+                                                    rows = r,
+                                                    epoch = ?epoch,
+                                                    reason = reason.as_str(),
+                                                    decision = "apply_failed",
+                                                    "Failed to apply PTY resize"
+                                                );
+                                                continue;
                                             }
+                                        } else {
+                                            tracing::debug!(
+                                                session_id = %session_id,
+                                                cols = c,
+                                                rows = r,
+                                                epoch = ?epoch,
+                                                reason = reason.as_str(),
+                                                decision = "noop",
+                                                "Skipping no-op PTY resize"
+                                            );
                                         }
+
+                                        let mut resized_msg = serde_json::json!({
+                                            "type": "pty_resized",
+                                            "cols": c,
+                                            "rows": r,
+                                        });
+                                        if let Some(epoch) = epoch {
+                                            resized_msg["epoch"] = serde_json::json!(epoch);
+                                        }
+                                        let _ = ws_tx.send(Message::Text(resized_msg.to_string())).await;
                                     }
                                 }
                                 _ => {}
@@ -561,3 +637,37 @@ fn restore_terminal_mode(original: Option<nix::sys::termios::Termios>) {
 
 #[cfg(not(unix))]
 fn restore_terminal_mode(_original: Option<()>) {}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_resize_reason;
+    use crate::protocol::PtyResizeReason;
+
+    #[test]
+    fn wrapper_reason_resolves_restore_from_zero_dimensions() {
+        assert_eq!(
+            resolve_resize_reason(0, 24, Some("geometry_change")),
+            PtyResizeReason::DetachRestore
+        );
+        assert_eq!(
+            resolve_resize_reason(80, 0, Some("attach_init")),
+            PtyResizeReason::DetachRestore
+        );
+    }
+
+    #[test]
+    fn wrapper_reason_maps_known_and_defaults_unknown() {
+        assert_eq!(
+            resolve_resize_reason(80, 24, Some("attach_init")),
+            PtyResizeReason::AttachInit
+        );
+        assert_eq!(
+            resolve_resize_reason(80, 24, Some("keyboard_overlay")),
+            PtyResizeReason::KeyboardOverlay
+        );
+        assert_eq!(
+            resolve_resize_reason(80, 24, Some("future_reason")),
+            PtyResizeReason::GeometryChange
+        );
+    }
+}

--- a/cli/src/pty_wrapper.rs
+++ b/cli/src/pty_wrapper.rs
@@ -966,7 +966,7 @@ mod tests {
             &ctx.socket_name,
             &ctx.session_name,
             "/bin/sh",
-            &vec!["-lc".to_string(), "printf tmux-test".to_string()],
+            &vec!["-lc".to_string(), "sleep 3".to_string()],
             ".",
             80,
             24,

--- a/cli/src/pty_wrapper.rs
+++ b/cli/src/pty_wrapper.rs
@@ -278,12 +278,14 @@ fn setup_tmux_session(
     run_tmux_checked(&mut new_session, "new-session")?;
 
     // Best-effort options for deterministic rendering behavior.
+    // NOTE: window-size must remain dynamic so wrapper PTY resizes propagate
+    // into tmux panes when mobile dimensions change.
     let window_target = format!("{}:0", session_name);
     let option_sets: [(&str, &str, &str, &str); 4] = [
         ("set-option", session_name, "status", "off"),
         ("set-option", session_name, "allow-rename", "off"),
         ("set-option", session_name, "history-limit", "200000"),
-        ("set-window-option", &window_target, "window-size", "manual"),
+        ("set-window-option", &window_target, "window-size", "latest"),
     ];
     for (command, target, key, value) in option_sets {
         let mut option_cmd = tmux_base_command(socket_name);
@@ -984,6 +986,26 @@ mod tests {
             output.status.success(),
             "expected has-session success: {}",
             String::from_utf8_lossy(&output.stderr)
+        );
+
+        let mut show_window_size = tmux_base_command(&ctx.socket_name);
+        let output = show_window_size
+            .arg("show-window-options")
+            .arg("-v")
+            .arg("-t")
+            .arg(format!("{}:0", &ctx.session_name))
+            .arg("window-size")
+            .output()
+            .expect("show-window-options output");
+        assert!(
+            output.status.success(),
+            "expected show-window-options success: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let window_size_mode = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        assert_eq!(
+            window_size_mode, "latest",
+            "expected tmux window-size to remain dynamic for client-driven resize propagation"
         );
 
         cleanup_tmux_session(&ctx);

--- a/cli/src/pty_wrapper.rs
+++ b/cli/src/pty_wrapper.rs
@@ -259,6 +259,28 @@ fn setup_tmux_session(
     cols: u16,
     rows: u16,
 ) -> Result<(), WrapError> {
+    // Bootstrap a dedicated tmux server first so global options apply before
+    // the wrapped CLI starts. This avoids races where frame CLIs enter
+    // alternate-screen at launch and drop scrollback history.
+    let mut start_server = tmux_base_command(socket_name);
+    start_server.arg("start-server");
+    let _ = run_tmux_checked(&mut start_server, "start-server");
+
+    let mut pre_alt_screen = tmux_base_command(socket_name);
+    pre_alt_screen
+        .arg("set-window-option")
+        .arg("-g")
+        .arg("alternate-screen")
+        .arg("off");
+    if let Err(err) = run_tmux_checked(&mut pre_alt_screen, "alternate-screen") {
+        tracing::debug!(
+            socket = socket_name,
+            session = session_name,
+            error = %err,
+            "Ignoring non-fatal pre-session alternate-screen option failure"
+        );
+    }
+
     let mut new_session = tmux_base_command(socket_name);
     new_session
         .arg("new-session")
@@ -281,10 +303,11 @@ fn setup_tmux_session(
     // NOTE: window-size must remain dynamic so wrapper PTY resizes propagate
     // into tmux panes when mobile dimensions change.
     let window_target = format!("{}:0", session_name);
-    let option_sets: [(&str, &str, &str, &str); 4] = [
+    let option_sets: [(&str, &str, &str, &str); 5] = [
         ("set-option", session_name, "status", "off"),
         ("set-option", session_name, "allow-rename", "off"),
         ("set-option", session_name, "history-limit", "200000"),
+        ("set-window-option", &window_target, "alternate-screen", "off"),
         ("set-window-option", &window_target, "window-size", "latest"),
     ];
     for (command, target, key, value) in option_sets {
@@ -1007,6 +1030,26 @@ mod tests {
         assert_eq!(
             window_size_mode, "latest",
             "expected tmux window-size to remain dynamic for client-driven resize propagation"
+        );
+
+        let mut show_alt_screen = tmux_base_command(&ctx.socket_name);
+        let output = show_alt_screen
+            .arg("show-window-options")
+            .arg("-v")
+            .arg("-t")
+            .arg(format!("{}:0", &ctx.session_name))
+            .arg("alternate-screen")
+            .output()
+            .expect("show-window-options alternate-screen output");
+        assert!(
+            output.status.success(),
+            "expected alternate-screen query success: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let alt_screen_mode = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        assert_eq!(
+            alt_screen_mode, "off",
+            "expected tmux alternate-screen to be disabled so scrollback is preserved"
         );
 
         cleanup_tmux_session(&ctx);

--- a/cli/src/pty_wrapper.rs
+++ b/cli/src/pty_wrapper.rs
@@ -133,6 +133,34 @@ fn request_terminal_resize(cols: u16, rows: u16) {
     set_stdout_winsize(cols, rows);
 }
 
+fn clear_local_terminal_view(stdout: &mut std::io::Stdout) {
+    if !stdout.is_terminal() {
+        return;
+    }
+    let _ = stdout.write_all(b"\x1b[2J\x1b[H");
+    let _ = stdout.flush();
+}
+
+fn should_clear_local_before_resize(
+    reason: PtyResizeReason,
+    previous: Option<(u16, u16)>,
+    cols: u16,
+) -> bool {
+    match reason {
+        PtyResizeReason::AttachInit
+        | PtyResizeReason::ReconnectSync
+        | PtyResizeReason::DetachRestore => true,
+        PtyResizeReason::GeometryChange => previous.is_some_and(|(prev_cols, _)| prev_cols != cols),
+        PtyResizeReason::KeyboardOverlay | PtyResizeReason::Unknown => false,
+    }
+}
+
+fn jitter_resize_target(cols: u16, rows: u16) -> (u16, u16) {
+    let jitter_cols = if cols > 1 { cols - 1 } else { cols + 1 };
+    let jitter_rows = if rows > 1 { rows - 1 } else { rows + 1 };
+    (jitter_cols, jitter_rows)
+}
+
 fn resolve_resize_reason(cols: u16, rows: u16, reason: Option<&str>) -> PtyResizeReason {
     if cols == 0 || rows == 0 {
         return PtyResizeReason::DetachRestore;
@@ -481,8 +509,47 @@ pub async fn run_wrapped(config: WrapConfig) -> Result<i32, WrapError> {
                                             }
                                         }
 
-                                        let should_resize = last_applied_pty_size != Some((c, r));
+                                        let force_noop_refresh = matches!(
+                                            reason,
+                                            PtyResizeReason::AttachInit | PtyResizeReason::ReconnectSync
+                                        ) && last_applied_pty_size == Some((c, r));
+
+                                        if should_clear_local_before_resize(reason, last_applied_pty_size, c) {
+                                            tracing::debug!(
+                                                session_id = %session_id,
+                                                cols = c,
+                                                rows = r,
+                                                epoch = ?epoch,
+                                                reason = reason.as_str(),
+                                                "Clearing local terminal before semantic resize"
+                                            );
+                                            clear_local_terminal_view(&mut stdout);
+                                        }
+
+                                        let should_resize =
+                                            force_noop_refresh || last_applied_pty_size != Some((c, r));
                                         if should_resize {
+                                            if force_noop_refresh {
+                                                let (jitter_c, jitter_r) = jitter_resize_target(c, r);
+                                                tracing::debug!(
+                                                    session_id = %session_id,
+                                                    cols = c,
+                                                    rows = r,
+                                                    jitter_cols = jitter_c,
+                                                    jitter_rows = jitter_r,
+                                                    epoch = ?epoch,
+                                                    reason = reason.as_str(),
+                                                    decision = "force_noop_redraw",
+                                                    "Applying jitter resize before final target to force redraw"
+                                                );
+                                                let _ = master.resize(PtySize {
+                                                    rows: jitter_r,
+                                                    cols: jitter_c,
+                                                    pixel_width: 0,
+                                                    pixel_height: 0,
+                                                });
+                                            }
+
                                             let resized = master.resize(PtySize {
                                                 rows: r,
                                                 cols: c,
@@ -640,7 +707,9 @@ fn restore_terminal_mode(_original: Option<()>) {}
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_resize_reason;
+    use super::{
+        jitter_resize_target, resolve_resize_reason, should_clear_local_before_resize,
+    };
     use crate::protocol::PtyResizeReason;
 
     #[test]
@@ -669,5 +738,45 @@ mod tests {
             resolve_resize_reason(80, 24, Some("future_reason")),
             PtyResizeReason::GeometryChange
         );
+    }
+
+    #[test]
+    fn clear_policy_prefers_attach_detach_and_width_changes() {
+        assert!(should_clear_local_before_resize(
+            PtyResizeReason::AttachInit,
+            Some((80, 24)),
+            80
+        ));
+        assert!(should_clear_local_before_resize(
+            PtyResizeReason::ReconnectSync,
+            Some((80, 24)),
+            80
+        ));
+        assert!(should_clear_local_before_resize(
+            PtyResizeReason::DetachRestore,
+            Some((80, 24)),
+            120
+        ));
+        assert!(should_clear_local_before_resize(
+            PtyResizeReason::GeometryChange,
+            Some((80, 24)),
+            100
+        ));
+        assert!(!should_clear_local_before_resize(
+            PtyResizeReason::GeometryChange,
+            Some((80, 24)),
+            80
+        ));
+        assert!(!should_clear_local_before_resize(
+            PtyResizeReason::KeyboardOverlay,
+            Some((80, 24)),
+            80
+        ));
+    }
+
+    #[test]
+    fn jitter_target_always_changes_dimensions() {
+        assert_eq!(jitter_resize_target(80, 24), (79, 23));
+        assert_eq!(jitter_resize_target(1, 1), (2, 2));
     }
 }

--- a/cli/src/setup.rs
+++ b/cli/src/setup.rs
@@ -513,7 +513,7 @@ pub fn run_setup_wizard() -> io::Result<Config> {
     );
     println!(
         "{}",
-        "You can remove it anytime with: mobilecli shell-hook uninstall".dimmed()
+        "You can remove it anytime with: mobilecli autolaunch uninstall".dimmed()
     );
     println!();
 
@@ -536,7 +536,7 @@ pub fn run_setup_wizard() -> io::Result<Config> {
     } else {
         println!(
             "{}",
-            "Skipped. You can enable later with: mobilecli shell-hook install".dimmed()
+            "Skipped. You can enable later with: mobilecli autolaunch install".dimmed()
         );
     }
 

--- a/cli/src/shell_hook.rs
+++ b/cli/src/shell_hook.rs
@@ -34,7 +34,7 @@ fn bash_snippet() -> String {
     format!(
         r#"{BEGIN_MARKER}
 # Automatically launch mobilecli in interactive terminals.
-# To disable: export MOBILECLI_NO_AUTO_LAUNCH=1  (or run: mobilecli shell-hook uninstall)
+# To disable: export MOBILECLI_NO_AUTO_LAUNCH=1  (or run: mobilecli autolaunch uninstall)
 if [ -z "$MOBILECLI_NO_AUTO_LAUNCH" ] && [ -z "$MOBILECLI_SESSION" ] && [ -t 0 ] && command -v mobilecli >/dev/null 2>&1; then
   exec mobilecli
 fi
@@ -48,7 +48,7 @@ fn fish_snippet() -> String {
     format!(
         r#"{BEGIN_MARKER}
 # Automatically launch mobilecli in interactive terminals.
-# To disable: set -gx MOBILECLI_NO_AUTO_LAUNCH 1  (or run: mobilecli shell-hook uninstall)
+# To disable: set -gx MOBILECLI_NO_AUTO_LAUNCH 1  (or run: mobilecli autolaunch uninstall)
 if not set -q MOBILECLI_NO_AUTO_LAUNCH; and not set -q MOBILECLI_SESSION; and isatty stdin; and command -v mobilecli >/dev/null 2>&1
     exec mobilecli
 end
@@ -62,7 +62,7 @@ fn powershell_snippet() -> String {
     format!(
         r#"{BEGIN_MARKER}
 # Automatically launch mobilecli in interactive terminals.
-# To disable: $env:MOBILECLI_NO_AUTO_LAUNCH = "1"  (or run: mobilecli shell-hook uninstall)
+# To disable: $env:MOBILECLI_NO_AUTO_LAUNCH = "1"  (or run: mobilecli autolaunch uninstall)
 if (-not $env:MOBILECLI_NO_AUTO_LAUNCH -and -not $env:MOBILECLI_SESSION -and [Environment]::UserInteractive -and (Get-Command mobilecli -ErrorAction SilentlyContinue)) {{
     & mobilecli
     exit $LASTEXITCODE
@@ -147,7 +147,7 @@ fn install() -> Result<(), Box<dyn std::error::Error>> {
         );
         println!(
             "  To remove permanently:  {}",
-            "mobilecli shell-hook uninstall".dimmed()
+            "mobilecli autolaunch uninstall".dimmed()
         );
     }
 
@@ -220,10 +220,7 @@ fn status() -> Result<(), Box<dyn std::error::Error>> {
 
     if !any_found {
         println!("{} Auto-launch: not installed", "○".dimmed());
-        println!(
-            "  Run {} to enable",
-            "mobilecli shell-hook install".cyan()
-        );
+        println!("  Run {} to enable", "mobilecli autolaunch install".cyan());
     }
 
     Ok(())
@@ -510,18 +507,4 @@ pub fn install_quiet() -> bool {
         }
     }
     any_installed
-}
-
-/// Convenience: uninstall shell hook non-interactively.
-pub fn uninstall_quiet() -> bool {
-    let targets = all_possible_targets();
-    let mut any_removed = false;
-    for target in &targets {
-        if target.path.exists() {
-            if let Ok(true) = remove_from(&target) {
-                any_removed = true;
-            }
-        }
-    }
-    any_removed
 }

--- a/cli/src/shell_hook.rs
+++ b/cli/src/shell_hook.rs
@@ -396,7 +396,7 @@ fn powershell_profile_path(home: &std::path::Path) -> Option<PathBuf> {
         if dir.exists() || which::which("pwsh").is_ok() {
             return Some(dir.join("Microsoft.PowerShell_profile.ps1"));
         }
-        return None;
+        None
     }
 
     #[cfg(not(any(unix, windows)))]
@@ -502,7 +502,7 @@ pub fn install_quiet() -> bool {
     let targets = detect_shell_targets();
     let mut any_installed = false;
     for target in &targets {
-        if let Ok(true) = install_into(&target) {
+        if let Ok(true) = install_into(target) {
             any_installed = true;
         }
     }

--- a/cli/src/tmux.rs
+++ b/cli/src/tmux.rs
@@ -1,0 +1,29 @@
+/// Sanitize arbitrary identifiers for tmux socket/session tokens.
+pub fn sanitize_tmux_token(raw: &str) -> String {
+    let mut out: String = raw
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    if out.is_empty() {
+        out.push_str("session");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sanitize_tmux_token;
+
+    #[test]
+    fn sanitize_tmux_token_replaces_unsafe_chars() {
+        assert_eq!(sanitize_tmux_token("abc123"), "abc123");
+        assert_eq!(sanitize_tmux_token("abc/def"), "abc-def");
+        assert_eq!(sanitize_tmux_token(""), "session");
+    }
+}

--- a/docs/TERMINAL_SCROLLBACK_DIMENSION_ROOT_CAUSE_PLAN_2026-02-24.md
+++ b/docs/TERMINAL_SCROLLBACK_DIMENSION_ROOT_CAUSE_PLAN_2026-02-24.md
@@ -1,0 +1,131 @@
+# Terminal Scrollback + Dimension Reliability Plan (2026-02-24)
+
+## Goal
+
+Make mobile viewing behave like a stable mirror of desktop terminal usage:
+
+- no persistent "stuck mobile dimensions" after mobile leaves
+- no session blanks on reopen
+- reliable scrolling/history behavior in mobile and desktop
+- no CLI-specific command hacks as primary strategy
+
+## Confirmed Findings (Evidence-Based)
+
+1. Some modern agent CLIs (verified: Codex, Kimi) use frame-style redraw output, not append-only line output.
+
+- Observed control patterns in live PTY capture:
+  - `CSI J` clears
+  - repeated cursor repositioning
+  - scroll-region resets
+- Result: visible viewport content can be overwritten in place during normal output.
+
+2. "History disappearing" is not solely a mobile rendering bug.
+
+- Same overwrite behavior is visible in desktop terminal output stream for frame CLIs.
+- This means terminal-native scrollback alone cannot guarantee full conversational history for every CLI.
+
+3. Stuck dimensions are lifecycle/state issues, not just rendering.
+
+- If mobile viewer state is stale (reconnect races, duplicate sockets), restore can be skipped.
+- This leaves wrapper PTY in prior resized dimensions.
+
+## Changes Already Applied in This Pass
+
+1. Explicit detach restore from mobile leave path
+
+- `mobile/app/session/[id].tsx`
+- Sends `pty_resize` with `cols=0`, `rows=0`, `reason=detach_restore` before unsubscribe.
+
+2. Keyboard resize churn suppression
+
+- `mobile/components/TerminalView.tsx`
+- Keyboard show/hide resize bursts are tagged `keyboard_overlay` (ignored by wrapper as geometry changes).
+
+3. Wrapper restore baseline hardening
+
+- `cli/src/pty_wrapper.rs`
+- Preserve-mode restore now uses captured pre-mobile baseline when available.
+
+4. Stale socket eviction by logical sender ID (new)
+
+- `mobile/hooks/useSync.ts`: `hello` now includes `sender_id`.
+- `cli/src/protocol.rs`: `ClientMessage::Hello` includes optional `sender_id`.
+- `cli/src/daemon.rs`:
+  - tracks `mobile_sender_addrs`
+  - evicts prior socket for same sender ID
+  - cleans associated view/watch state
+
+5. Wrapper resize semantics cleanup (new)
+
+- `cli/src/pty_wrapper.rs`
+- `detach_restore` reason mapping corrected.
+- No-op jitter redraw now restricted to `pty` runtime only (not tmux).
+
+## Remaining Work (Execution Plan)
+
+## Phase 1: Deterministic Viewer-State Validation
+
+1. Run daemon in debug mode and capture attach/resize/unsubscribe/restore timeline.
+2. Add a short reproducible probe script for:
+   - subscribe
+   - resize to mobile dims
+   - unsubscribe
+   - verify restore request reached wrapper
+3. Validate no stale viewer entries persist after reconnect/reload loops.
+
+Acceptance:
+- Every focus-leave produces either explicit detach restore or last-viewer restore.
+- No session remains at mobile dims after leave when no active viewer exists.
+
+## Phase 2: Scrollback Semantics for Frame CLIs (Generic, Not CLI-Specific)
+
+1. Keep terminal-fidelity path as-is for live control.
+2. Add a daemon-side append-only "text transcript lane" derived from raw output stream:
+   - control-sequence stripped
+   - carriage-return normalized
+   - bounded buffer (separate from terminal scrollback)
+3. Expose transcript replay for mobile reopen and deep history scroll fallback.
+
+Acceptance:
+- Reopen never appears blank.
+- Users can scroll prior conversational text even when terminal viewport is frame-redrawn.
+
+## Phase 3: Mobile Scroll UX Reliability
+
+1. Ensure full-surface gesture capture remains active after reconnect.
+2. Verify scroll can start from any vertical region, not only over text glyphs.
+3. Add regression checks for keyboard/input bar visibility during long output.
+
+Acceptance:
+- Scroll gesture works from anywhere in terminal pane.
+- Input bar text never becomes invisible/cut off.
+
+## Phase 4: Verification Matrix Before Next Build
+
+Run and record outcomes for:
+
+- Codex
+- Claude
+- Gemini
+- Kimi
+- OpenCode
+- Plain shell
+
+For each:
+
+1. cold open
+2. long output
+3. mobile leave/reenter x3
+4. deep scroll back
+5. keyboard show/hide while output streams
+
+Release gate:
+- no stuck dimensions
+- no blank reopen
+- no duplicate input bars
+- usable deep history path in mobile
+
+## Notes
+
+- This plan intentionally avoids relying on per-CLI launch flags as the primary fix strategy.
+- For frame CLIs, terminal-native scrollback is inherently limited by in-place redraw behavior; transcript lane is the generic reliability layer.

--- a/docs/TMUX_ARCHITECTURE_REWRITE_PLAN_2026-02-24.md
+++ b/docs/TMUX_ARCHITECTURE_REWRITE_PLAN_2026-02-24.md
@@ -1,5 +1,7 @@
 # TMUX Architecture Rewrite Plan
 
+Superseded by `docs/TMUX_RUNTIME_EXECUTION_MASTER_PLAN_2026-02-24.md` (detailed execution version).
+
 Date: 2026-02-24
 Status: Proposed (execute after approval)
 Scope: `cli/` daemon + wrapper + protocol integration, mobile protocol-compatible first
@@ -166,4 +168,3 @@ Pass criteria:
 4. Implement tmux-backed `get_session_history`.
 5. Validate Codex reattach path end-to-end on tmux runtime.
 6. Open focused PR: `feat/tmux-runtime-phase1` with evidence logs.
-

--- a/docs/TMUX_ARCHITECTURE_REWRITE_PLAN_2026-02-24.md
+++ b/docs/TMUX_ARCHITECTURE_REWRITE_PLAN_2026-02-24.md
@@ -1,0 +1,169 @@
+# TMUX Architecture Rewrite Plan
+
+Date: 2026-02-24
+Status: Proposed (execute after approval)
+Scope: `cli/` daemon + wrapper + protocol integration, mobile protocol-compatible first
+
+## 1. Objective
+
+Build a reliable local terminal streaming system where:
+- desktop and phone can control/view the same live terminal session,
+- mobile uses mobile-native dimensions,
+- reconnects do not blank or duplicate terminal UI,
+- desktop terminal is never forcibly cleared by mobile detach,
+- behavior remains stable for Codex/Claude/any TUI/CLI.
+
+## 2. Why Current PTY Model Fails
+
+Current design has daemon + wrapper manually coordinating:
+- raw PTY byte replay,
+- attach/detach resize races,
+- suppression/unsuppression timing,
+- epoch ordering across reconnects.
+
+This has repeatedly produced:
+- blank reattach windows,
+- clipped history,
+- duplicate prompt/input artifacts,
+- desktop clears on detach.
+
+Root issue: we are re-implementing terminal multiplexer semantics in ad-hoc logic.
+
+## 3. Why tmux
+
+tmux is a local terminal multiplexer built for exactly this problem:
+- persistent session lifecycle,
+- multi-client attach/detach,
+- stable scrollback,
+- full-screen app handling.
+
+Control mode gives machine-readable events (`%output`, `%session-changed`, etc.) and explicit client sizing controls.
+
+Research references:
+- tmux control mode: https://github.com/tmux/tmux/wiki/Control-Mode
+- tmux window size policy (`largest|smallest|latest|manual`): https://www.man7.org/linux/man-pages/man1/tmux.1.html
+- gotty/ttyd recommend tmux for reliable shared single-process terminals:
+  - https://github.com/yudai/gotty
+  - https://github.com/tsl0922/ttyd
+
+## 4. Important Constraint (must be explicit)
+
+A single interactive terminal process has one effective PTY geometry at a time.
+
+So "desktop and mobile both attached at different dimensions" is a policy choice, not a free capability.
+
+We will support explicit size policy modes:
+- `active_client` (default): whichever client is actively interacting drives size (`tmux window-size latest`).
+- `desktop_priority`: desktop size wins unless user explicitly hands control to mobile.
+- `fixed`: stable canonical size (no automatic resize), useful for maximum determinism.
+
+## 5. Target Architecture
+
+### 5.1 Session Runtime
+
+Each MobileCLI session runs inside tmux.
+
+Daemon owns a control-mode client per session group and maps:
+- MobileCLI `session_id` -> tmux session/window/pane IDs.
+
+### 5.2 Data Flow
+
+- Output to mobile: tmux control-mode `%output` stream.
+- Input from mobile: tmux `send-keys`/pane input command path.
+- Reconnect history: tmux `capture-pane` (authoritative scrollback), not custom PTY ring replay semantics.
+- Resize: daemon issues tmux client/window sizing commands based on selected policy.
+
+### 5.3 Desktop Behavior
+
+Desktop keeps normal terminal behavior; no daemon-driven clear/reset on detach.
+
+## 6. Migration Strategy
+
+## Phase 0 - Freeze and Cleanup
+
+- Stop adding new replay/suppression heuristics to current PTY path.
+- Remove known harmful behavior immediately (desktop clear-on-detach).
+- Add feature flag:
+  - `MOBILECLI_RUNTIME=pty|tmux` (default `pty` for short rollout period).
+
+## Phase 1 - tmux Adapter (daemon-only)
+
+Implement `TmuxAdapter` in daemon:
+- create/list/attach/kill tmux sessions,
+- start control-mode client (`tmux -CC ...`) and parse control stream,
+- map `%output` to existing `pty_bytes` protocol for mobile compatibility,
+- implement `get_session_history` via `capture-pane`.
+
+## Phase 2 - Wrapper Integration
+
+Update wrapper startup path:
+- launch command inside tmux session (`new -A -s ...`),
+- attach desktop terminal as normal tmux client,
+- stop forwarding raw PTY websocket bytes for tmux sessions.
+
+## Phase 3 - Resize Policy Engine
+
+Implement explicit policy resolver in daemon:
+- `active_client`, `desktop_priority`, `fixed`.
+- no keyboard-overlay resize forwarding.
+- deterministic logs for every size decision.
+
+## Phase 4 - Mobile Simplification
+
+Once tmux runtime is stable:
+- remove alt-screen suppression/epoch dependency for tmux sessions,
+- keep protocol shape stable where possible,
+- request history from daemon/tmux as authoritative restore source.
+
+## Phase 5 - Default Switch
+
+- Run matrix validation.
+- Make `tmux` default runtime.
+- Keep `pty` runtime as fallback for one release, then deprecate.
+
+## 7. Test and Validation Gates
+
+## 7.1 Automated
+
+- daemon unit tests for tmux parser, reconnect, size policy transitions.
+- integration tests for:
+  - detach/reattach with no output,
+  - stale/out-of-order resize messages,
+  - long Codex output history retrieval.
+
+## 7.2 Manual Matrix
+
+Required before default switch:
+- CLIs: Codex, Claude, bash, vim, htop, less.
+- Hosts: KDE Konsole + at least one additional terminal emulator.
+- Devices: iOS + Android.
+- Scenarios:
+  - repeated detach/reattach,
+  - keyboard show/hide storms,
+  - background/foreground,
+  - dual-view (desktop + mobile) with explicit size policy checks.
+
+Pass criteria:
+- no desktop clear on detach,
+- no blank mobile reattach,
+- no duplicated input bars/prompts,
+- history restoration not clipped unexpectedly under configured scrollback limits.
+
+## 8. Rollout and Risk Control
+
+- Runtime flag default remains `pty` until matrix pass.
+- Add runtime telemetry counters:
+  - blank-reattach incidents,
+  - duplicate-line detection signals,
+  - reconnect restore latency.
+- If tmux runtime fails any critical gate, keep fallback and block release.
+
+## 9. Immediate Execution Tasks
+
+1. Remove desktop clear-on-detach behavior in wrapper.
+2. Create `TmuxAdapter` module and control-mode parser skeleton.
+3. Add runtime feature flag plumbing.
+4. Implement tmux-backed `get_session_history`.
+5. Validate Codex reattach path end-to-end on tmux runtime.
+6. Open focused PR: `feat/tmux-runtime-phase1` with evidence logs.
+

--- a/docs/TMUX_RUNTIME_EXECUTION_MASTER_PLAN_2026-02-24.md
+++ b/docs/TMUX_RUNTIME_EXECUTION_MASTER_PLAN_2026-02-24.md
@@ -1,0 +1,410 @@
+# TMUX Runtime Execution Master Plan
+
+Date: 2026-02-24
+Status: Ready for implementation
+Owner: Codex
+Scope: `cli/` first, `mobile/` only where required for reliability
+Supersedes: `docs/TMUX_ARCHITECTURE_REWRITE_PLAN_2026-02-24.md`
+
+## 1) Mission and Non-Negotiables
+
+Goal:
+- A user can open/view/control the same desktop terminal session from phone with stable behavior.
+
+Non-negotiables:
+- No desktop terminal wipe/clear on mobile detach.
+- No blank mobile reattach for Codex/TUI sessions.
+- No duplicated input bars or ghost layers.
+- Reconnect restores visible state and scrollback deterministically.
+- Works for unknown future terminal tools as long as they run in a terminal.
+- Keep existing mobile protocol compatible during migration.
+
+## 2) Verified Baseline Facts (No Assumptions)
+
+### 2.1 Current implementation facts from code
+
+1. Wrapper currently contains explicit local clear logic in resize path.
+- File: `cli/src/pty_wrapper.rs`
+- Functions: `clear_local_terminal_view`, `should_clear_local_before_resize`, resize handling in `run_wrapped`.
+
+2. Daemon session model is wrapper/PTy-stream-centric.
+- File: `cli/src/daemon.rs`
+- Entry points: `handle_pty_session`, `process_client_msg`, `restore_pty_size`, `send_sessions_list`, `persist_sessions_to_file`.
+
+3. Mobile suppresses PTY bytes for alt-screen sessions until `pty_resized` is observed.
+- File: `mobile/hooks/useSync.ts`
+- Logic: `subscribe_ack` sets suppression; `pty_bytes` dropped while suppressed; suppression released on `pty_resized`.
+
+4. Mobile requests replay using `get_session_history` after resize ack.
+- File: `mobile/hooks/useSync.ts`
+
+5. Protocol is already resize-reason/epoch aware and supports `session_history`.
+- File: `cli/src/protocol.rs`
+
+6. Local environment has tmux available.
+- Command: `tmux -V`
+- Result: `tmux 3.4`
+
+### 2.2 Verified tmux behavior from local probes
+
+Probe A: control mode framing + notifications
+- Command: `tmux -C ...`
+- Observed: `%begin/%end`, `%session-changed`, `%layout-change`, `%output`, `%exit`.
+
+Probe B: output encoding in control mode
+- Observed `%output` contains escaped sequences (example `\015\012`) not raw bytes.
+- Implication: parser/decoder is required before forwarding to `pty_bytes`.
+
+Probe C: history capture fidelity
+- Command: `capture-pane -p` and `capture-pane -p -e`
+- Observed: `-e` preserves ANSI styling escapes in captured text.
+
+Probe D: input injection works through tmux command channel
+- Command: `send-keys -t %pane ...`
+- Observed output echoed back through `%output`.
+
+## 3) External Research Summary
+
+Primary references:
+- tmux control mode protocol and notifications.
+- tmux session/window sizing policy (`window-size`: `largest|smallest|manual|latest`).
+- tmux client flags (`ignore-size`, `read-only`, `pause-after`) for multi-client behavior.
+- gotty/ttyd usage patterns showing tmux-backed sharing as established practice.
+
+Sources:
+- https://github.com/tmux/tmux/wiki/Control-Mode
+- https://man7.org/linux/man-pages/man1/tmux.1.html
+- https://github.com/tmux/tmux/wiki
+- https://github.com/yudai/gotty
+- https://github.com/tsl0922/ttyd/wiki
+- https://github.com/xtermjs/xterm.js
+
+## 4) Why Rewrite Is Required
+
+The current daemon+wrapper path re-implements terminal multiplexer semantics manually:
+- replay assembly,
+- attach/detach ordering,
+- resize race control,
+- suppression timing coordination.
+
+This is structurally fragile for frame-rendered TUIs. The reliability goal needs native multiplexer semantics, not more heuristics.
+
+## 5) Target Architecture
+
+## 5.1 Runtime abstraction
+
+Introduce runtime backend abstraction in daemon:
+- `PtyRuntime` (legacy backend)
+- `TmuxRuntime` (new backend)
+
+Selection:
+- env/config flag `MOBILECLI_RUNTIME=pty|tmux`.
+- initial default remains `pty` until tmux passes matrix.
+
+## 5.2 Session model additions
+
+Extend daemon session state with runtime metadata:
+- `runtime: pty|tmux`
+- tmux IDs:
+  - `tmux_session`
+  - `tmux_window`
+  - `tmux_pane`
+  - `tmux_control_client`
+- authoritative `history_limit_lines` and current policy mode.
+
+## 5.3 TmuxAdapter responsibilities
+
+New module set (proposed):
+- `cli/src/tmux/mod.rs`
+- `cli/src/tmux/command.rs` (safe command builder/executor)
+- `cli/src/tmux/control_parser.rs` (`%begin/%end/%output/...` parser)
+- `cli/src/tmux/runtime.rs` (backend implementation)
+- `cli/src/runtime/mod.rs` (backend trait)
+
+Responsibilities:
+- spawn/attach/kill tmux sessions
+- maintain one control-mode client per managed session
+- decode `%output` stream -> daemon `pty_bytes`
+- map mobile input -> `send-keys` (raw and text-safe paths)
+- produce `session_history` via `capture-pane` (`-e` mode when requested)
+- manage resize policy through tmux commands only
+
+## 5.4 Mobile compatibility contract
+
+Phase 1-2 keep existing mobile protocol messages:
+- `pty_bytes`
+- `subscribe_ack`
+- `pty_resized`
+- `session_history`
+
+Optional additive fields (backward compatible) for migration:
+- in `sessions` items: `runtime`, `capabilities`
+- in `subscribe_ack`: `runtime`, `replay_mode`
+
+## 6) Size Policy (Explicit and Deterministic)
+
+Single process cannot have multiple simultaneous PTY sizes. We will support explicit policy modes:
+
+1. `active_client` (default)
+- most recently interactive client drives tmux window size (`window-size latest` behavior aligned).
+- mobile can be authoritative while actively interacting.
+
+2. `desktop_priority`
+- desktop-attached client dominates size unless user explicitly requests mobile control.
+
+3. `fixed`
+- canonical stable size; no dynamic resize by client activity.
+
+Policy state tracked per session:
+- active controller (`desktop|mobile|none`)
+- last interaction timestamp per client
+- current target size and reason
+
+## 7) Detailed Workstreams
+
+## W1 - Immediate Stabilization (short-lived before tmux cutover)
+
+Purpose:
+- prevent actively harmful behavior while rewrite is built.
+
+Tasks:
+- disable desktop clear on detach/restore path.
+- stop adding new replay/suppression heuristics in `pty` backend.
+
+Exit criteria:
+- no explicit clear sequence emitted on detach path in wrapper logs.
+
+## W2 - Runtime Backend Abstraction
+
+Tasks:
+- create backend trait for common operations:
+  - spawn session
+  - subscribe/unsubscribe viewer
+  - send input
+  - resize
+  - history snapshot
+  - close
+- migrate daemon code paths to call backend interface.
+
+Files:
+- `cli/src/daemon.rs`
+- new `cli/src/runtime/*`
+
+Exit criteria:
+- `pty` backend behavior unchanged under tests.
+
+## W3 - Tmux Control-Mode Backbone
+
+Tasks:
+- implement robust parser for control-mode line stream:
+  - `%begin/%end/%error`
+  - `%output`
+  - `%layout-change`
+  - `%exit`
+  - `%session-changed`
+- implement output decode for escaped content from `%output`.
+- forward decoded data as protocol `pty_bytes`.
+
+Exit criteria:
+- integration harness shows command output roundtrip from tmux to mobile stream.
+
+## W4 - Input, History, and Session Lifecycle
+
+Tasks:
+- input mapping:
+  - `send_input raw=true` path to tmux (byte-safe translation strategy)
+  - normal text path with newline semantics parity.
+- history mapping:
+  - `get_session_history` -> `capture-pane` with configurable start/end and ANSI preservation mode.
+- session close:
+  - close pane/window/session and emit `session_ended` reliably.
+
+Exit criteria:
+- repeated reconnect gets deterministic non-empty history for Codex sessions.
+
+## W5 - Resize and Policy Engine
+
+Tasks:
+- implement policy resolver with structured decision logs.
+- map mobile/desktop resize intents to tmux commands.
+- enforce one transaction pipeline: request -> apply -> ack.
+
+Exit criteria:
+- no stale resize race causes blank screen in harness tests.
+
+## W6 - Mobile Adjustments (only where required)
+
+Allowed changes (if needed for correctness):
+- condition suppression behavior on runtime capability.
+- for tmux runtime, avoid dropping useful bytes while waiting for ack when safe.
+- simplify reconnect replay trigger if daemon provides authoritative snapshot immediately.
+
+Files (if needed):
+- `mobile/hooks/useSync.ts`
+- `mobile/components/TerminalView.tsx`
+
+Exit criteria:
+- no app-side suppression deadlock on tmux sessions.
+
+## W7 - Rollout and Default Switch
+
+Tasks:
+- expose runtime selector in config/env.
+- run full matrix.
+- switch default to tmux only after gates pass.
+- keep `pty` fallback one release.
+
+## 8) PR and Branch Plan
+
+PR 1: runtime abstraction scaffold
+- no behavior change.
+
+PR 2: tmux parser + control client + output pipeline
+- hidden behind flag.
+
+PR 3: tmux input/history/close + tests
+
+PR 4: resize policy engine + deterministic logs
+
+PR 5: minimal mobile changes (only if required by runtime capability)
+
+PR 6: docs + rollout flags + matrix results
+
+Each PR must include:
+- hypothesis
+- changed files
+- commands/tests run
+- evidence snippets/screenshots
+- risk and rollback note
+
+## 9) Test Strategy
+
+## 9.1 Automated (required)
+
+Rust unit tests:
+- control-mode parser correctness
+- `%output` decode correctness
+- policy resolver decisions
+- history snapshot translation
+
+Rust integration tests (new harness):
+- spawn tmux session, emit output, verify websocket `pty_bytes`
+- detach/reattach with no new output
+- stale/out-of-order resize acks
+- long-output history retrieval (Codex-like volume)
+
+Existing checks:
+- `cargo check --manifest-path cli/Cargo.toml`
+- `cargo test --manifest-path cli/Cargo.toml`
+
+Mobile checks when touched:
+- `cd mobile && npx tsc --noEmit`
+
+## 9.2 Manual matrix (required)
+
+Hosts:
+- KDE Konsole (required)
+- one additional emulator (GNOME Terminal/WezTerm)
+
+Clients:
+- iOS
+- Android
+
+CLIs:
+- Codex
+- Claude
+- bash
+- vim
+- htop
+- less
+
+Scenarios:
+- 20x detach/reattach loop
+- keyboard show/hide stress
+- background/foreground reconnect
+- dual view with each size policy mode
+- long session scrollback recovery
+
+Pass criteria:
+- no desktop clear
+- no blank mobile reattach
+- no duplicate prompt bars
+- history not unexpectedly chopped within configured limits
+
+## 10) Observability and Evidence Requirements
+
+Add structured logs for tmux backend:
+- session_id
+- runtime
+- command/action
+- size policy decision
+- controller (`desktop|mobile`)
+- requested size, applied size
+- ack token/sequence
+- replay source (`live_output|capture_pane`)
+
+Task log file (required):
+- `docs/TMUX_RUNTIME_TASK_LOG_2026-02-24.md`
+
+Every task entry includes:
+- hypothesis
+- files touched
+- commands run
+- evidence
+- result
+- next action
+
+No build/release without completed task-log evidence for each major change.
+
+## 11) Risks and Mitigations
+
+Risk: tmux control parser bugs cause dropped output
+- Mitigation: parser unit tests + golden fixtures from real `%output` lines.
+
+Risk: raw input parity differences vs current PTY path
+- Mitigation: explicit raw-input conformance tests (arrow keys, ctrl keys, enter semantics).
+
+Risk: Windows hosts without tmux
+- Mitigation: runtime fallback to `pty` backend by platform capability.
+
+Risk: performance/backpressure on high-volume output
+- Mitigation: bounded queues, optional pause strategies, instrumentation for lag.
+
+Risk: mobile suppression logic conflicts with tmux runtime
+- Mitigation: runtime capability gating and staged mobile changes only when proven necessary.
+
+## 12) Rollback Plan
+
+- Runtime flag can force legacy backend:
+  - `MOBILECLI_RUNTIME=pty`
+- Keep legacy backend codepath until tmux default has one release soak.
+- If critical regressions occur, revert default and keep tmux behind opt-in.
+
+## 13) Pre-Implementation Verification Checklist
+
+Must pass before coding phase starts:
+- [x] tmux installed and version confirmed (`3.4`).
+- [x] control mode notifications observed locally.
+- [x] `%output` escaping behavior observed and documented.
+- [x] `capture-pane -e` ANSI preservation observed.
+- [ ] verify alt-screen capture strategy for curses workloads (`vim/htop`) with `capture-pane` modes.
+- [ ] verify exact resize command mapping for per-policy behavior in control clients.
+- [ ] verify macOS host behavior with tmux backend on one machine.
+
+## 14) Definition of Done
+
+Done when all are true:
+- tmux backend supports spawn, input, output, history, resize, close.
+- desktop detach does not clear terminal.
+- Codex mobile reattach is reliable across stress matrix.
+- logs and task evidence complete.
+- tmux runtime can be enabled safely with fallback available.
+
+## 15) Immediate Next Actions
+
+1. Create task log file and record baseline probes.
+2. Implement runtime abstraction scaffold (no behavior change).
+3. Implement tmux control parser with fixture tests.
+4. Wire tmux output to websocket `pty_bytes` behind runtime flag.
+5. Validate Codex reattach loop on tmux runtime before any mobile edits.
+

--- a/docs/TMUX_RUNTIME_TASK_LOG_2026-02-24.md
+++ b/docs/TMUX_RUNTIME_TASK_LOG_2026-02-24.md
@@ -1,0 +1,100 @@
+# TMUX Runtime Task Log
+
+Date: 2026-02-24
+Owner: Codex
+Branch: `feat/tmux-runtime-phase1`
+
+## Task T-001 - Baseline architecture and failure-shape capture
+Date: 2026-02-24
+Owner: Codex
+
+Hypothesis:
+- Current PTY-centric attach/replay logic is structurally fragile for frame-rendered TUIs and should be replaced with tmux-backed session multiplexing.
+
+Changes:
+- No code changes.
+- Audited current behavior and code paths:
+  - `cli/src/daemon.rs`
+  - `cli/src/pty_wrapper.rs`
+  - `mobile/hooks/useSync.ts`
+  - `mobile/components/TerminalView.tsx`
+  - `mobile/app/session/[id].tsx`
+
+Commands:
+- `rg -n "should_clear_local_before_resize|clear|DetachRestore|subscribe_ack|pty_resized|suppressPtyUntilResize" cli/src mobile`
+- `sed -n ...` on files listed above.
+
+Evidence:
+- Desktop clear logic exists in wrapper resize policy path.
+- Mobile suppresses `pty_bytes` until `pty_resized` ack for alt-screen sessions.
+- Daemon session model is tied to wrapper `register_pty` stream.
+
+Result:
+- pass
+
+Next action:
+- Validate tmux control-mode semantics and output/history behavior with local probes.
+
+## Task T-002 - tmux capability probe and command semantics verification
+Date: 2026-02-24
+Owner: Codex
+
+Hypothesis:
+- tmux control mode and capture-pane provide sufficient primitives to replace custom PTY replay/resize heuristics.
+
+Changes:
+- No code changes.
+- Ran local tmux probes for:
+  - control mode notification framing,
+  - `%output` data representation,
+  - `capture-pane` ANSI behavior,
+  - `send-keys` input roundtrip.
+
+Commands:
+- `tmux -V`
+- tmux probe scripts using `tmux -L <sock> -f /dev/null ...`
+- `man tmux | col -b | sed -n ...`
+
+Evidence:
+- `tmux 3.4` available locally.
+- Control mode emits `%begin/%end`, `%output`, `%layout-change`, `%exit`.
+- `%output` is escaped text (decoded parser needed).
+- `capture-pane -e` preserves ANSI escapes.
+- `send-keys` roundtrip observed in `%output` stream.
+
+Result:
+- pass
+
+Next action:
+- Finalize comprehensive execution plan with explicit phases, risks, test gates, and rollback.
+
+## Task T-003 - Master execution plan publication
+Date: 2026-02-24
+Owner: Codex
+
+Hypothesis:
+- A file-level, phase-gated plan with explicit verification checkpoints will prevent further speculative fixes and support reliable execution.
+
+Changes:
+- Added:
+  - `docs/TMUX_RUNTIME_EXECUTION_MASTER_PLAN_2026-02-24.md`
+
+Commands:
+- Document authoring only.
+
+Evidence:
+- Plan includes:
+  - validated baseline facts,
+  - tmux-backed target architecture,
+  - runtime abstraction strategy,
+  - phased PR sequence,
+  - automated/manual matrix gates,
+  - risk and rollback controls,
+  - pre-implementation verification checklist.
+
+Result:
+- pass
+
+Next action:
+- Begin Phase W2 runtime abstraction scaffold on `feat/tmux-runtime-phase1`.
+

--- a/docs/TMUX_RUNTIME_TASK_LOG_2026-02-24.md
+++ b/docs/TMUX_RUNTIME_TASK_LOG_2026-02-24.md
@@ -168,3 +168,42 @@ Result:
 
 Next action:
 - Commit changes and run target manual validation loop on Codex session attach/detach cycles using tmux runtime.
+
+## Task T-006 - tmux reconnect replay correctness hardening
+Date: 2026-02-24
+Owner: Codex
+
+Hypothesis:
+- Blank reattach and "terminal code pasted into chat" regressions come from replaying raw daemon PTY scrollback for tmux sessions instead of replaying an authoritative tmux pane snapshot.
+
+Changes:
+- Updated `cli/src/daemon.rs`:
+  - Added tmux metadata to in-memory session state (`tmux_socket`, `tmux_session`).
+  - Derived tmux identifiers from `session_id` at registration for runtime `tmux`.
+  - Added tmux snapshot helpers:
+    - `capture_tmux_history_blocking`
+    - `capture_tmux_history`
+    - `tail_scrollback_bytes` (fallback path).
+  - `GetSessionHistory` now prefers tmux `capture-pane -p -e -S -200000` for tmux sessions; falls back to daemon buffer only on capture failure.
+  - `Subscribe` now:
+    - disables deferred raw replay for tmux runtime,
+    - sends immediate `session_history` snapshot from tmux when available.
+  - `broadcast_pty_resized` now skips deferred raw replay for tmux sessions (prevents corrupted frame replays).
+- Added daemon test:
+  - `tmux_capture_history_returns_snapshot_text`.
+
+Commands:
+- `cargo fmt --manifest-path cli/Cargo.toml`
+- `cargo check --manifest-path cli/Cargo.toml`
+- `cargo test --manifest-path cli/Cargo.toml --bin mobilecli -- --skip test_list_directory_sorts_directories_first`
+
+Evidence:
+- Test suite result after patch: `36 passed; 0 failed` (1 filtered known filesystem test).
+- New tmux capture test validates snapshot contains expected marker from live tmux session.
+- Deferred raw replay path explicitly bypassed for runtime `tmux`.
+
+Result:
+- pass
+
+Next action:
+- Install updated release binary locally and run Codex mobile attach/detach verification loop with logs.

--- a/docs/TMUX_RUNTIME_TASK_LOG_2026-02-24.md
+++ b/docs/TMUX_RUNTIME_TASK_LOG_2026-02-24.md
@@ -98,3 +98,73 @@ Result:
 Next action:
 - Begin Phase W2 runtime abstraction scaffold on `feat/tmux-runtime-phase1`.
 
+## Task T-004 - Wrapper stabilization and tmux runtime cutover
+Date: 2026-02-24
+Owner: Codex
+
+Hypothesis:
+- Running wrapped sessions through a tmux-backed runtime and removing local clear sequences will eliminate desktop wipe behavior and provide multiplexer semantics needed for frame-TUI reliability.
+
+Changes:
+- Updated `cli/src/pty_wrapper.rs`:
+  - Added runtime resolver (`MOBILECLI_RUNTIME=auto|tmux|pty`), defaulting `auto` to tmux when available.
+  - Added tmux session bootstrap (`new-session`) and cleanup (`kill-server`) helpers.
+  - Session registration now reports runtime metadata to daemon.
+  - Wrapper now launches tmux attach client in PTY when tmux runtime is active.
+  - Removed destructive local terminal clear path from resize handling.
+- Added wrapper tests:
+  - runtime override behavior,
+  - tmux token sanitization,
+  - tmux bootstrap/cleanup roundtrip.
+
+Commands:
+- `cargo check --manifest-path cli/Cargo.toml`
+- `cargo test --manifest-path cli/Cargo.toml --bin mobilecli -- --skip test_list_directory_sorts_directories_first`
+- `rg -n "2J\\x1b\\[H|clear_local_terminal_view|should_clear_local_before_resize" cli/src/pty_wrapper.rs cli/src/daemon.rs`
+
+Evidence:
+- `rg` returned no matches for local clear/clear-policy functions in wrapper/daemon.
+- tmux lifecycle unit test passes: `pty_wrapper::tests::tmux_session_bootstrap_and_cleanup_roundtrip`.
+- Resize handling still preserves `attach_init/reconnect_sync` no-op redraw path via jittered PTY resize.
+
+Result:
+- pass
+
+Next action:
+- Propagate runtime metadata through daemon session surfaces and increase replay headroom.
+
+## Task T-005 - Daemon runtime metadata and replay headroom
+Date: 2026-02-24
+Owner: Codex
+
+Hypothesis:
+- Tagging session runtime at daemon level and increasing scrollback headroom reduces replay truncation risk and enables runtime-aware diagnostics during rollout.
+
+Changes:
+- Updated `cli/src/daemon.rs`:
+  - `PtySession` now stores `runtime`.
+  - registration parser accepts `runtime` from wrapper (`register_pty` payload).
+  - sessions list serialization includes runtime.
+  - increased `DEFAULT_SCROLLBACK_MAX_BYTES` from `512KB` to `2MB`.
+  - updated tests/fixtures for new struct field and constant.
+- Updated `cli/src/protocol.rs`:
+  - `SessionListItem` now includes optional `runtime`.
+
+Commands:
+- `cargo fmt --manifest-path cli/Cargo.toml`
+- `cargo check --manifest-path cli/Cargo.toml`
+- `cargo test --manifest-path cli/Cargo.toml --bin mobilecli -- --skip test_list_directory_sorts_directories_first`
+- `rg -n "runtime" cli/src/pty_wrapper.rs cli/src/daemon.rs cli/src/protocol.rs`
+
+Evidence:
+- Test run after formatting: `35 passed; 0 failed` (with one known filtered test).
+- Runtime metadata appears in:
+  - wrapper registration payload,
+  - daemon session state,
+  - protocol session list schema.
+
+Result:
+- pass
+
+Next action:
+- Commit changes and run target manual validation loop on Codex session attach/detach cycles using tmux runtime.

--- a/docs/TMUX_RUNTIME_TASK_LOG_2026-02-24.md
+++ b/docs/TMUX_RUNTIME_TASK_LOG_2026-02-24.md
@@ -207,3 +207,45 @@ Result:
 
 Next action:
 - Install updated release binary locally and run Codex mobile attach/detach verification loop with logs.
+
+## Task T-007 - Mobile terminal report input filtering + lightweight tmux TUI replay
+Date: 2026-02-24
+Owner: Codex
+
+Hypothesis:
+- Reattach-injected `0;276;0c` text is terminal-report feedback (`ESC[>0;276;0c`) emitted by mobile xterm and forwarded as raw CLI input. Blank/black reattach after repeated cycles is aggravated by oversized tmux history replay for frame TUIs.
+
+Changes:
+- Updated `cli/src/daemon.rs`:
+  - Added raw-input sanitizer:
+    - `strip_terminal_report_sequences`
+    - `is_terminal_report_csi`
+  - `SendInput(raw=true)` now removes terminal report reply sequences before forwarding to PTY.
+  - `capture_tmux_history` now supports replay mode:
+    - full scrollback (`-S -200000`) for text sessions,
+    - visible-pane snapshot only for frame/alt-screen sessions.
+  - `Subscribe` for tmux frame sessions no longer sends eager full replay.
+  - `GetSessionHistory` for tmux now selects replay mode based on `render_as_tui`.
+- Added tests:
+  - `strip_terminal_reports_drops_secondary_da_reply`
+  - `strip_terminal_reports_preserves_user_escape_keys`
+  - `strip_terminal_reports_removes_embedded_report_sequences`
+
+Commands:
+- `cargo fmt --manifest-path cli/Cargo.toml`
+- `cargo check --manifest-path cli/Cargo.toml`
+- `cargo test --manifest-path cli/Cargo.toml --bin mobilecli -- --skip test_list_directory_sorts_directories_first`
+
+Evidence:
+- Test suite result after patch: `39 passed; 0 failed` (1 filtered known filesystem test).
+- Sanitizer test specifically validates dropping `ESC[>0;276;0c` while preserving real key sequences (arrow keys).
+- tmux history capture test remains passing with new API shape.
+
+Result:
+- pass
+
+Next action:
+- Rebuild/install daemon binary and run targeted mobile attach/detach loops validating:
+  - no injected `0;276;0c`,
+  - no black blank on repeated reopen,
+  - stable Codex scroll/render behavior.

--- a/docs/TMUX_RUNTIME_TASK_LOG_2026-02-24.md
+++ b/docs/TMUX_RUNTIME_TASK_LOG_2026-02-24.md
@@ -405,3 +405,223 @@ Result:
 
 Next action:
 - Deploy daemon update (restart required) and mobile update (new build required), then re-test with targeted scenarios: open session, rotate, keyboard show/hide, leave/reopen.
+
+## Task T-012 - Mobile scrollback depth + pan/auto-follow stabilization
+Date: 2026-02-24
+Owner: Codex
+
+Hypothesis:
+- Two factors are causing "hard to scroll up" behavior even when rendering is otherwise stable:
+  1) local xterm scrollback is capped at 1000 lines, truncating long AI sessions;
+  2) auto-follow can keep snapping back to bottom while users start touch panning upward.
+
+Changes:
+- Updated `mobile/assets/xterm.html`:
+  - Increased local xterm scrollback from `1000` to `20000` lines.
+  - Tightened at-bottom threshold from `50px` to `8px` for faster transition out of follow mode.
+  - Removed 50ms debounced scroll-state update; now evaluates at-bottom state on each viewport scroll event.
+  - Added `autoFollowSuspendedUntil` guard so touch pan interactions temporarily suppress output auto-follow.
+  - On touch pan movement, force `isAtBottom=false` immediately and report state.
+  - Auto-follow now only scrolls on new output when not suspended.
+- Updated `mobile/hooks/useSync.ts`:
+  - `get_session_history` now requests `max_bytes: 8 * 1024 * 1024` to pull a deeper backlog on reattach.
+- Updated `cli/src/daemon.rs`:
+  - Increased default daemon scrollback buffer cap from `2MB` to `8MB`.
+  - Updated unit test expectation for default scrollback size.
+
+Commands:
+- `npx tsc --noEmit` (mobile)
+- `cargo check --manifest-path cli/Cargo.toml`
+- `cargo test --manifest-path cli/Cargo.toml --bin mobilecli -- --skip test_list_directory_sorts_directories_first`
+
+Evidence:
+- TypeScript compile clean.
+- Rust check clean.
+- Rust unit tests: `42 passed; 0 failed` (1 filtered known filesystem test).
+- Diffs show direct changes in scrollback depth and touch/auto-follow arbitration paths.
+
+Result:
+- pass
+
+Next action:
+- Validate on-device with long-output sessions (Codex/Gemini/OpenCode) using:
+  - continuous output while attempting to scroll up,
+  - reopen + deep history scrolling,
+  - repeated attach/detach loops.
+
+## Task T-013 - Scrollback continuity on reattach + tmux TUI gating correction
+Date: 2026-02-24
+Owner: Codex
+
+Hypothesis:
+- Scrollback loss and chopped reopen history are amplified by two behaviors:
+  1) mobile performs destructive `reset()` on alt-screen reattach paths (clears local buffer);
+  2) daemon classifies tmux frame-mode sessions as "alt-screen-like" and therefore disables tmux scrollback snapshots, even when the session is not truly in alternate screen.
+
+Additional probe evidence:
+- Local tmux probe shows `capture-pane -S` only returns deep history for main-screen output; for alternate-screen output it remains viewport-limited (~24 lines).
+- Therefore, non-alt tmux sessions should not be forced into alt suppression/replay path.
+
+Changes:
+- Updated `cli/src/daemon.rs`:
+  - Added `should_treat_as_tui_for_mobile(runtime, in_alt_screen, frame_render_mode)`.
+  - For `runtime=tmux`, only true `in_alt_screen` now activates TUI suppression semantics.
+  - `GetSessionHistory` for tmux now uses capture-pane scrollback only for non-alt sessions; alt sessions fall back to daemon scrollback path.
+  - Added debug logs clarifying when daemon scrollback fallback is used for session history.
+  - Added unit test: `tmux_mobile_tui_gating_uses_real_alt_screen_only`.
+- Updated `mobile/components/TerminalView.tsx`:
+  - Removed destructive `xterm.reset()` calls from reconnect/late-ack/onReady alt-screen paths.
+  - Kept reconnect resize sync and refit behavior, but now non-destructive to preserve local scrollback continuity.
+  - iOS input path now triggers `maybeScrollToBottom()` after queued input to reduce "typing but prompt not visible" incidents.
+- Updated `mobile/assets/xterm.html`:
+  - `fitTerminal()` now forces `term.refresh(...)` after fit to reduce post-resize cursor/input-line rendering gaps.
+
+Commands:
+- tmux probe:
+  - `tmux ... capture-pane -p -e -S -2000` with main-screen output => deep history (`224` lines)
+  - same probe with explicit alt-screen output => viewport-limited (`24` lines)
+- `npx tsc --noEmit` (mobile)
+- `cargo check --manifest-path cli/Cargo.toml`
+- `cargo test --manifest-path cli/Cargo.toml --bin mobilecli -- --skip test_list_directory_sorts_directories_first`
+
+Evidence:
+- TypeScript compile clean.
+- Rust check clean.
+- Rust tests: `43 passed; 0 failed` (1 filtered known filesystem test).
+- tmux probe confirms main-vs-alt history behavior difference and validates gating change rationale.
+
+Result:
+- pass
+
+Next action:
+- Build/install updated daemon and run on-device reopen/scroll stress with Codex + Gemini + OpenCode.
+- Validate specifically:
+  - deep upward scrolling after reattach,
+  - no duplicate input bars,
+  - prompt/input visibility while typing.
+
+## Task T-014 - Desktop-fit default pivot + runtime-aware suppression
+Date: 2026-02-24
+Owner: Codex
+
+Hypothesis:
+- Persisting duplicate/frame spill and unreliable scrolling are driven by mobile-dimension PTY resize churn on frame-heavy CLIs. A desktop-canonical PTY with mobile desktop-fit rendering should be more stable.
+
+Changes:
+- Updated `cli/src/protocol.rs`:
+  - `SubscribeAck` now includes optional `runtime` field.
+- Updated `cli/src/daemon.rs`:
+  - `SubscribeAck` now sends session runtime (`pty`/`tmux`).
+  - tmux session classification uses `should_treat_as_tui_for_mobile`; non-alt tmux sessions avoid TUI suppression path.
+  - `GetSessionHistory` requests tmux capture-pane only for non-alt tmux sessions; alt sessions use daemon scrollback fallback.
+- Updated `mobile/hooks/useSync.ts`:
+  - subscribe handling is now runtime-aware:
+    - `in_alt_screen && runtime != tmux` => existing suppression path,
+    - `in_alt_screen && runtime == tmux` => no suppression, immediate history request.
+- Updated `mobile/components/TerminalView.tsx`:
+  - Added desktop-fit default mode (`DESKTOP_FIT_MODE=true`): mobile resize intents now send `keyboard_overlay` sync acks instead of geometry-changing resizes.
+  - `geometry_change` PTY resize emissions disabled in desktop-fit mode.
+  - reconnect/attach sync paths now use non-destructive sync intent.
+- Updated `mobile/assets/xterm.html`:
+  - font size reduced `13 -> 11` to increase effective visible columns in desktop-fit mode.
+
+Commands:
+- `npx tsc --noEmit` (mobile)
+- `cargo check --manifest-path cli/Cargo.toml`
+- `cargo test --manifest-path cli/Cargo.toml --bin mobilecli -- --skip test_list_directory_sorts_directories_first`
+
+Evidence:
+- TypeScript compile clean.
+- Rust tests: `43 passed; 0 failed` (1 filtered known filesystem test).
+- No compile/runtime regressions from protocol extension.
+
+Result:
+- pass
+
+Next action:
+- Rebuild/restart daemon locally and run on-device Gemini/Codex stress loop in desktop-fit mode.
+- If stability is confirmed, keep this as default and expose optional mobile-canonical mode behind a toggle later.
+
+## Task T-015 - Mobile-canonical resize restoration + replay chunking hardening
+Date: 2026-02-24
+Owner: Codex
+
+Hypothesis:
+- Remaining Gemini/Codex render spill is caused by a size contract violation: xterm was fit to mobile while backend PTY stayed desktop-sized (`DESKTOP_FIT_MODE=true`), so cursor-addressed redraws rendered against mismatched cols/rows.
+- Blank/chopped reopen is caused by oversized `session_history` payloads being dropped/stalled in mobile queues/injection batching.
+
+Changes:
+- Updated `mobile/components/TerminalView.tsx`:
+  - Switched to mobile-canonical PTY sizing (`DESKTOP_FIT_MODE=false`).
+  - Re-enabled geometry resize propagation via `sendResizeIntent(..., 'geometry_change')`.
+  - Keyboard-driven row changes are no longer ignored in canonical mode (prevents input line from drifting under keyboard).
+  - On refocus, perform local `xterm.reset()` before replay/refit to prevent duplicate stale frame overlay.
+- Updated `mobile/hooks/useSync.ts`:
+  - Increased pending PTY queue limits (`chunks: 4000`, `bytes: 20MB`).
+  - Added base64 chunk splitter (`64KB`, 4-byte aligned) before callback/queue delivery.
+  - Queue eviction now preserves at least one newest chunk, preventing self-drop of large replay payloads.
+- Updated `mobile/components/XTermView.tsx`:
+  - Added defensive base64 bridge chunking (`64KB`, 4-byte aligned).
+  - Increased pre-ready pending write cap (`100 -> 2000`) so large replay bursts survive WebView readiness races.
+- Updated `mobile/assets/xterm.html`:
+  - Added full-screen `#gesture-layer` to capture pan/tap across entire terminal area.
+  - Touch action switched to manual pan (`touch-action:none`) for terminal/canvas/gesture layer.
+  - Pan handlers now attach to gesture layer (fallback terminal element).
+  - Font size adjusted to `12` (from desktop-fit `11`) for canonical readability.
+
+Commands:
+- `npx tsc --noEmit` (mobile)
+- `cargo test --manifest-path cli/Cargo.toml --bin mobilecli -- --skip test_list_directory_sorts_directories_first`
+
+Evidence:
+- TypeScript compile clean.
+- Rust tests remain clean: `43 passed; 0 failed` (1 filtered known filesystem test).
+- Code-level root-cause closure:
+  - PTY/xterm dimension mismatch removed by canonical resize.
+  - Large replay payload can no longer be dropped as a single oversize chunk or stuck behind bridge batch-size limits.
+
+Result:
+- pass
+
+Next action:
+- Install this mobile build and run targeted on-device regression loop:
+  - Gemini/Codex/OpenCode startup layout,
+  - leave/reopen same session (no blank, no duplicate prompt bars),
+  - deep upward scrolling through long history,
+  - keyboard show/hide while typing (input line remains visible).
+
+## Task T-016 - Pre-build hygiene audit and dead-path cleanup
+Date: 2026-02-24
+Owner: Codex
+
+Hypothesis:
+- Remaining reliability risk is now mostly code hygiene (stale fallback/overlay scaffolding) rather than core PTY transport logic. Removing dormant paths reduces future regressions.
+
+Changes:
+- Updated `mobile/components/TerminalView.tsx`:
+  - Removed dormant desktop-fit branching and keyboard-overlay-only branch logic.
+  - Kept canonical path only: mobile resize events always propagate via `onPtyResize(..., geometry_change)`.
+  - Removed no-longer-used keyboard transition refs tied to the old desktop-fit path.
+- Updated `mobile/assets/xterm.html`:
+  - Removed disabled selection-overlay DOM/CSS/functions and associated no-op scheduling hooks.
+  - Removed overlay function calls from `refitTerminal`.
+  - Kept terminal gesture layer + paste interception + xterm core path only.
+- Updated `mobile/hooks/useSync.ts`:
+  - Corrected stale comment wording for tmux alt-screen replay behavior.
+
+Commands:
+- `npx tsc --noEmit` (mobile)
+- `cargo check --manifest-path cli/Cargo.toml`
+- `cargo test --manifest-path cli/Cargo.toml --bin mobilecli -- --skip test_list_directory_sorts_directories_first`
+
+Evidence:
+- TypeScript compile clean.
+- Rust check clean.
+- Rust tests: `43 passed; 0 failed`.
+- `rg` audit confirms overlay code paths removed from `assets/xterm.html`.
+
+Result:
+- pass
+
+Next action:
+- Device validation run before new build submission (Gemini/Codex/OpenCode + reopen + deep scroll + keyboard visibility).

--- a/docs/TMUX_RUNTIME_TASK_LOG_2026-02-24.md
+++ b/docs/TMUX_RUNTIME_TASK_LOG_2026-02-24.md
@@ -365,3 +365,43 @@ Result:
 
 Next action:
 - Restart daemon with updated binary (when safe, since active sessions are currently running) and re-test mobile attach/reopen sizing behavior.
+
+## Task T-011 - Attach resize race fix + mobile TUI surface stabilization
+Date: 2026-02-24
+Owner: Codex
+
+Hypothesis:
+- Two independent issues still produce clipped/unnatural mobile terminal output:
+  1) daemon may ignore initial `attach_init` resize when it arrives before subscribe view-count registration (race), leaving tmux at desktop geometry;
+  2) mobile forces local `ESC[?1049h` for frame-rendered TUIs, creating visual artifacts/duplication on CLIs that are frame-mode but not true alt-screen.
+
+Changes:
+- Updated `cli/src/daemon.rs`:
+  - Added `should_ignore_resize_without_viewers(...)`.
+  - Viewer-count guard now allows `attach_init` and `reconnect_sync` bootstrap resizes even when current viewer count is still zero.
+  - Added test: `no_viewer_guard_allows_bootstrap_resizes`.
+- Updated `mobile/components/TerminalView.tsx`:
+  - Removed forced local `\x1b[?1049h` injection on subscribe-ack paths.
+  - Keep local terminal reset behavior so stale frame remnants are cleared without faking alternate-screen state.
+- Updated `mobile/components/XTermView.tsx`:
+  - Added forced post-ready refit (immediate + delayed) to recover from early-fit layout races that can produce undersized row/col calculations.
+
+Commands:
+- `npx tsc --noEmit` (mobile)
+- `cargo fmt --manifest-path cli/Cargo.toml`
+- `cargo check --manifest-path cli/Cargo.toml`
+- `cargo test --manifest-path cli/Cargo.toml --bin mobilecli -- --skip test_list_directory_sorts_directories_first`
+
+Evidence:
+- Rust tests now: `42 passed; 0 failed` (1 filtered known filesystem test).
+- TypeScript compile clean.
+- Code paths directly address:
+  - ignored bootstrap resize race,
+  - forced faux-alt-screen injection for frame-mode TUIs,
+  - pre-layout fit timing race in WebView.
+
+Result:
+- pass
+
+Next action:
+- Deploy daemon update (restart required) and mobile update (new build required), then re-test with targeted scenarios: open session, rotate, keyboard show/hide, leave/reopen.

--- a/docs/TMUX_RUNTIME_TASK_LOG_2026-02-24.md
+++ b/docs/TMUX_RUNTIME_TASK_LOG_2026-02-24.md
@@ -249,3 +249,89 @@ Next action:
   - no injected `0;276;0c`,
   - no black blank on repeated reopen,
   - stable Codex scroll/render behavior.
+
+## Task T-008 - Stateful split-sequence filtering + tmux TUI capture retry
+Date: 2026-02-24
+Owner: Codex
+
+Hypothesis:
+- `0;276;0c` injection persists when xterm emits DA reply split across websocket frames (e.g. `ESC[>` then `0;276;0c`). Stateless filtering misses this. Intermittent black reattach also occurs when pane snapshot is captured before TUI redraw settles.
+
+Changes:
+- Updated `cli/src/daemon.rs`:
+  - Added per-session `raw_input_tail` state to `PtySession`.
+  - Replaced stateless raw-input filter path with stateful filter:
+    - `strip_terminal_report_sequences_stateful`
+    - preserves normal split key escapes, drops split terminal report replies.
+  - `SendInput(raw=true)` now mutates per-session tail and filters before forwarding.
+  - Added `capture_tmux_history_with_retry` + `snapshot_has_visible_content`.
+  - TUI pane snapshot path now retries capture up to 3x with short delay to avoid post-resize blank captures.
+- Added tests:
+  - `strip_terminal_reports_stateful_drops_split_da_reply`
+  - `strip_terminal_reports_stateful_preserves_split_arrow_key`
+
+Commands:
+- `cargo fmt --manifest-path cli/Cargo.toml`
+- `cargo check --manifest-path cli/Cargo.toml`
+- `cargo test --manifest-path cli/Cargo.toml --bin mobilecli -- --skip test_list_directory_sorts_directories_first`
+
+Evidence:
+- Test suite result: `41 passed; 0 failed` (1 filtered known filesystem test).
+- New split-sequence tests verify exact failure mode (`ESC[>0;276;0c`) is dropped even when fragmented across messages.
+- No compile warnings after gating helper-only wrapper with `#[cfg(test)]`.
+
+Result:
+- pass
+
+Next action:
+- Reinstall binary + restart daemon, then confirm on-device that injected `0;276;0c` is gone and repeated reattach no longer goes black.
+
+## Task T-009 - Reattach blank-screen race + scroll-surface hardening
+Date: 2026-02-24
+Owner: Codex
+
+Hypothesis:
+- Reopened sessions can go blank when initial `pty_bytes/session_history` arrive before mobile registers a `setPtyBytesCallback`; those bytes are dropped. Duplicate render/input bars are worsened by eager fallback history replay even when live redraw bytes are already flowing.
+
+Changes:
+- Updated `mobile/hooks/useSync.ts`:
+  - Added per-session buffering for subscribed sessions when callback is not yet attached.
+  - Flushed buffered PTY chunks immediately when `setPtyBytesCallback` is registered.
+  - Added replay state machine:
+    - alt-screen history replay now uses fallback timer after `pty_resized` ack,
+    - live bytes cancel pending replay,
+    - stale late session-history replies are dropped once live flow resumes.
+  - Added comprehensive cleanup for replay timers/state on unsubscribe/session close/connection reset.
+- Updated `mobile/assets/xterm.html`:
+  - Added capture-phase, full-surface touch pan handling over entire terminal area.
+  - Added movement thresholds and click suppression window to avoid double tap/focus races after touch interactions.
+  - Kept viewport-driven scroll-state reporting (`isAtBottom`) synchronized during touch pan.
+- Updated `cli/src/daemon.rs`:
+  - Increased tmux visible-pane snapshot retry window (`8x` attempts, `120ms` delay) for post-resize reattach stability.
+
+Commands:
+- `npx tsc --noEmit` (mobile)
+- `cargo check --manifest-path cli/Cargo.toml`
+- `cargo test --manifest-path cli/Cargo.toml --bin mobilecli -- --skip test_list_directory_sorts_directories_first`
+- `cargo build --release --manifest-path cli/Cargo.toml`
+- `install -m 755 cli/target/release/mobilecli /home/bigphoot/.local/bin/mobilecli`
+- `/home/bigphoot/.local/bin/mobilecli stop`
+- `nohup env RUST_LOG=mobilecli=debug /home/bigphoot/.local/bin/mobilecli daemon > /home/bigphoot/.mobilecli/daemon.log 2>&1 &`
+
+Evidence:
+- Rust tests: `41 passed; 0 failed` (1 filtered known filesystem test).
+- TypeScript compile: clean (`npx tsc --noEmit` with no errors).
+- Daemon process confirmed running from `/home/bigphoot/.local/bin/mobilecli`.
+- Replay path now explicitly handles:
+  - callback registration races,
+  - fallback replay only on missing live redraw,
+  - stale fallback snapshot suppression after live output resumes.
+
+Result:
+- pass
+
+Next action:
+- Validate on-device reopen loops (Codex + Claude) with the latest daemon/mobile pair and collect fresh screenshots/logs focused on:
+  - no blank reopen,
+  - no duplicate input bars,
+  - full-area scroll responsiveness.

--- a/docs/TMUX_RUNTIME_TASK_LOG_2026-02-24.md
+++ b/docs/TMUX_RUNTIME_TASK_LOG_2026-02-24.md
@@ -335,3 +335,33 @@ Next action:
   - no blank reopen,
   - no duplicate input bars,
   - full-area scroll responsiveness.
+
+## Task T-010 - tmux dynamic window sizing fix (root-cause for mobile dimension mismatch)
+Date: 2026-02-24
+Owner: Codex
+
+Hypothesis:
+- Mobile dimension mismatches and cut-off rendering persist because tmux session bootstrap set `window-size=manual`, which can lock pane geometry and prevent resize propagation from wrapper PTY resizes.
+
+Changes:
+- Updated `cli/src/pty_wrapper.rs`:
+  - Changed tmux bootstrap window option from `window-size manual` to `window-size latest`.
+  - Added code comment documenting why dynamic window-size mode is required for mobile resize propagation.
+- Strengthened wrapper integration test:
+  - `tmux_session_bootstrap_and_cleanup_roundtrip` now asserts tmux reports `window-size=latest` for the created session.
+
+Commands:
+- `cargo fmt --manifest-path cli/Cargo.toml`
+- `cargo check --manifest-path cli/Cargo.toml`
+- `cargo test --manifest-path cli/Cargo.toml --bin mobilecli -- --skip test_list_directory_sorts_directories_first`
+
+Evidence:
+- Wrapper source previously set `window-size=manual` in tmux bootstrap options.
+- Test suite remains green (`41 passed; 0 failed`) with new assertion.
+- This directly targets the resize propagation path responsible for mobile-vs-pane dimension divergence.
+
+Result:
+- pass
+
+Next action:
+- Restart daemon with updated binary (when safe, since active sessions are currently running) and re-test mobile attach/reopen sizing behavior.

--- a/docs/TUI_RENDERING_TASK_LOG_2026-02-23.md
+++ b/docs/TUI_RENDERING_TASK_LOG_2026-02-23.md
@@ -1,0 +1,127 @@
+# TUI Rendering Task Log
+
+Date: 2026-02-23
+Owner: Codex
+Branch: `fix/tui-rendering-reliability-v3`
+
+## Task T-001 - Baseline audit and failure-shape confirmation
+Date: 2026-02-23
+Owner: Codex
+
+Hypothesis:
+- Current failures come from non-semantic resize routing (keyboard/layout churn treated as PTY geometry) and missing server/wrapper-side guards.
+
+Changes:
+- No code changes.
+- Reviewed `docs/TUI_RENDERING_RELIABILITY_MASTER_PLAN_2026-02-23.md`.
+- Reviewed `docs/TUI_RENDERING_BUG.md`.
+- Audited resize flow in:
+  - `cli/src/protocol.rs`
+  - `cli/src/daemon.rs`
+  - `cli/src/pty_wrapper.rs`
+
+Commands:
+- `sed -n '1,260p' docs/TUI_RENDERING_RELIABILITY_MASTER_PLAN_2026-02-23.md`
+- `sed -n '1,320p' docs/TUI_RENDERING_BUG.md`
+- `rg -n "pty_resize|resize|SubscribeAck|keyboard|last_mobile_cols" cli/src mobile/components mobile/hooks`
+
+Evidence:
+- No semantic `reason` field in protocol.
+- Daemon accepted resize events without reason-class filtering.
+- Wrapper applied each resize directly; no reason-aware no-op/keyboard handling.
+
+Result:
+- pass
+
+Next action:
+- Implement semantic resize reasons and server-side decisioning first.
+
+## Task T-002 - Daemon semantic resize policy + decision logging
+Date: 2026-02-23
+Owner: Codex
+
+Hypothesis:
+- Enforcing semantic reasons and explicit server-side decisions (including keyboard/no-op ignores) will eliminate resize churn reaching PTY and reduce TUI corruption.
+
+Changes:
+- `cli/src/protocol.rs`: added `PtyResizeReason` and optional `reason` on `ClientMessage::PtyResize`.
+- `cli/src/daemon.rs`:
+  - Added `ResizeRequest` channel type and reason propagation to wrapper.
+  - Added `last_applied_size` session state.
+  - Added `resolve_resize_reason` and `is_noop_resize` helpers.
+  - Added structured resize-decision logs.
+  - Added keyboard-overlay ignore policy (with synthetic ack).
+  - Added no-op ignore policy (with synthetic ack).
+  - Added resize coalescing before forwarding to wrapper.
+  - Tagged restore path with `detach_restore`.
+
+Commands:
+- `cargo fmt --manifest-path cli/Cargo.toml`
+- `cargo check --manifest-path cli/Cargo.toml`
+- `cargo test --manifest-path cli/Cargo.toml daemon::tests:: -- --test-threads=1`
+
+Evidence:
+- `cargo check` passed.
+- Daemon tests passed (12/12 for `daemon::tests::` filter), including new reason/no-op tests.
+
+Result:
+- pass
+
+Next action:
+- Update PTY wrapper to consume semantic reasons and apply transition-safe resize behavior.
+
+## Task T-003 - PTY wrapper transition controller hardening
+Date: 2026-02-23
+Owner: Codex
+
+Hypothesis:
+- Wrapper-side reason-aware handling with no-op skipping + guaranteed `pty_resized` ack will stabilize attach/detach flows and avoid redundant SIGWINCH storms.
+
+Changes:
+- `cli/src/pty_wrapper.rs`:
+  - Added `resolve_resize_reason` for incoming daemon resize events.
+  - Added `last_applied_pty_size` tracking.
+  - Added keyboard-overlay ignore path with explicit ack.
+  - Added no-op resize skip while still acking epoch.
+  - Added structured logs for received/applied/ignored decisions.
+  - Added unit tests for reason resolution.
+
+Commands:
+- `cargo fmt --manifest-path cli/Cargo.toml`
+- `cargo check --manifest-path cli/Cargo.toml`
+- `cargo test --manifest-path cli/Cargo.toml pty_wrapper::tests:: -- --test-threads=1`
+
+Evidence:
+- `cargo check` passed.
+- Wrapper tests passed (2/2 for `pty_wrapper::tests::` filter).
+
+Result:
+- pass
+
+Next action:
+- Apply minimal mobile emission changes so keyboard transitions remain local-only.
+
+## Task T-004 - Validation checkpoint for CLI/daemon scope
+Date: 2026-02-23
+Owner: Codex
+
+Hypothesis:
+- End-to-end daemon/wrapper compile + targeted tests cover the newly introduced resize semantics sufficiently for PR review.
+
+Changes:
+- No code changes.
+
+Commands:
+- `cargo check --manifest-path cli/Cargo.toml`
+- `cargo test --manifest-path cli/Cargo.toml daemon::tests:: -- --test-threads=1`
+- `cargo test --manifest-path cli/Cargo.toml pty_wrapper::tests:: -- --test-threads=1`
+
+Evidence:
+- All targeted daemon/wrapper tests passed.
+- Existing unrelated warning remains: `shell_hook::uninstall_quiet` dead code.
+
+Result:
+- pass
+
+Next action:
+- Open/submit daemon PR and request Greptile review.

--- a/docs/TUI_RENDERING_TASK_LOG_2026-02-23.md
+++ b/docs/TUI_RENDERING_TASK_LOG_2026-02-23.md
@@ -125,3 +125,72 @@ Result:
 
 Next action:
 - Open/submit daemon PR and request Greptile review.
+
+## Task T-005 - Reopen history loss root-cause and daemon-only fix
+Date: 2026-02-24
+Owner: Codex
+
+Hypothesis:
+- Reopen history loss was caused by two daemon-side gaps:
+  - frame-rendered sessions skipped subscribe replay and could return with only tiny redraw output,
+  - 64KB scrollback rolled over too quickly for high-ANSI Codex/OpenCode flows.
+
+Changes:
+- `cli/src/daemon.rs`:
+  - increased `DEFAULT_SCROLLBACK_MAX_BYTES` from `64 * 1024` to `512 * 1024`.
+  - added deferred per-client replay queue for frame-rendered sessions: `pending_tui_replay`.
+  - on `subscribe` for frame-rendered sessions with existing scrollback, queue one replay for post-resize ack.
+  - on `broadcast_pty_resized`, send one replay payload (full scrollback) to queued viewers, then clear queue entry.
+  - added cleanup for deferred replay state on unsubscribe/disconnect/session close/end.
+
+Commands:
+- `cargo check --manifest-path cli/Cargo.toml`
+- `cargo test --manifest-path cli/Cargo.toml daemon::tests:: -- --nocapture`
+- `cargo test --manifest-path cli/Cargo.toml pty_wrapper::tests:: -- --nocapture`
+- websocket probe scripts (Python `websockets`) for attach/detach/reconnect flows with `get_session_history` + chunk-size capture.
+
+Evidence:
+- With old runtime binary path (`/home/bigphoot/.local/bin/mobilecli`) still active, reconnect showed:
+  - `history_before = 3894`
+  - post-resize `pty_bytes` sum = `323` (no full replay), matching user-visible "missing history".
+- After installing patched binary to runtime path and restarting daemon:
+  - reconnect showed `history_before = 3389` and first post-resize `pty_bytes` chunk = `3389` (full replay delivered).
+  - follow-up test: replay occurs only once per reattach (first resize replayed, second resize in same attach did not replay).
+- Scrollback-cap verification with high-volume bash output:
+  - `get_session_history.total_bytes = 143392` (> 65536), confirming rollover headroom increase.
+
+Result:
+- pass
+
+Next action:
+- Add regression tests for one-shot deferred replay and larger default scrollback, then reinstall daemon binary for local runtime parity.
+
+## Task T-006 - Regression tests and runtime parity install
+Date: 2026-02-24
+Owner: Codex
+
+Hypothesis:
+- Dedicated tests will prevent regression on the exact reconnect-history failure mode.
+
+Changes:
+- `cli/src/daemon.rs` tests:
+  - added `default_scrollback_is_large_enough_for_frame_clis`.
+  - added `pty_resized_replays_pending_tui_scrollback_only_once` (async test).
+
+Commands:
+- `cargo test --manifest-path cli/Cargo.toml daemon::tests::pty_resized_replays_pending_tui_scrollback_only_once -- --nocapture`
+- `cargo test --manifest-path cli/Cargo.toml daemon::tests::default_scrollback_is_large_enough_for_frame_clis -- --nocapture`
+- `cargo test --manifest-path cli/Cargo.toml daemon::tests:: -- --nocapture`
+- `cargo test --manifest-path cli/Cargo.toml pty_wrapper::tests:: -- --nocapture`
+- `install -m 755 cli/target/debug/mobilecli /home/bigphoot/.local/bin/mobilecli`
+
+Evidence:
+- New daemon tests pass.
+- Full targeted daemon/wrapper suites pass.
+- Runtime probe on installed daemon binary confirms reconnect first chunk equals pre-subscribe history bytes (`3219`), demonstrating working one-shot replay on actual running daemon.
+
+Result:
+- pass
+
+Next action:
+- Commit daemon-only patchset and continue mobile-side validation with no additional mobile code changes.


### PR DESCRIPTION
Remove tmux runtime and simplify to direct PTY-only architecture.

Changes:
- Major refactor of daemon.rs with attach-v2 replay and sequence gating
- Simplified pty_wrapper.rs with resize jitter removal
- Updated protocol.rs with new message types
- Added terminal detection for TUI sessions
- Updated tmux.rs with new capture logic

15 files changed, +3,738/-186 lines