### PR TITLE
feat: authoritative tmux viewport frame sync in daemon

### DIFF
--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -264,6 +264,8 @@ pub struct DaemonState {
     pub mobile_views: HashMap<SocketAddr, std::collections::HashSet<String>>,
     /// Current mobile controller socket for tmux shared viewport per session.
     pub tmux_viewport_controllers: HashMap<String, SocketAddr>,
+    /// Monotonic action sequence per tmux session for viewport frame/state ordering.
+    pub tmux_viewport_action_seq: HashMap<String, u64>,
     pub session_view_counts: HashMap<String, usize>,
     pub file_system: std::sync::Arc<FileSystemService>,
     pub file_watch_subscriptions: HashMap<SocketAddr, std::collections::HashSet<String>>,
@@ -306,6 +308,7 @@ impl DaemonState {
             push_tokens: Vec::new(),
             mobile_views: HashMap::new(),
             tmux_viewport_controllers: HashMap::new(),
+            tmux_viewport_action_seq: HashMap::new(),
             session_view_counts: HashMap::new(),
             file_system,
             file_watch_subscriptions: HashMap::new(),
@@ -1041,6 +1044,7 @@ async fn handle_pty_session(
         let mut st = state.write().await;
         if st.sessions.remove(&session_id).is_some() {
             st.tmux_viewport_controllers.remove(&session_id);
+            st.tmux_viewport_action_seq.remove(&session_id);
             clear_mobile_attach_for_session(&mut st, &session_id);
             // Notify about session end
             let msg = ServerMessage::SessionEnded {
@@ -2281,6 +2285,15 @@ async fn process_client_msg(
             let clamped_count = count
                 .unwrap_or(TMUX_VIEWPORT_DEFAULT_COUNT)
                 .clamp(1, TMUX_VIEWPORT_MAX_COUNT);
+            let action_seq = {
+                let mut st = state.write().await;
+                let seq = st
+                    .tmux_viewport_action_seq
+                    .entry(session_id.clone())
+                    .or_insert(0);
+                *seq = seq.saturating_add(1);
+                *seq
+            };
             let action_result = apply_tmux_viewport_action_with_retry(
                 socket.clone(),
                 name.clone(),
@@ -2288,11 +2301,38 @@ async fn process_client_msg(
                 clamped_count,
             )
             .await;
-            let viewport_state = query_tmux_viewport_state(socket, name)
+            let viewport_state = query_tmux_viewport_state(socket.clone(), name.clone())
                 .await
                 .unwrap_or_default();
+            let viewport_frame = capture_tmux_viewport_frame(
+                socket.clone(),
+                name.clone(),
+                viewport_state.in_copy_mode,
+            )
+            .await;
+            if let Some(frame) = viewport_frame {
+                let frame_msg = ServerMessage::TmuxViewportFrame {
+                    session_id: session_id.clone(),
+                    action_seq,
+                    data: BASE64.encode(frame),
+                    in_copy_mode: viewport_state.in_copy_mode,
+                    scroll_position: viewport_state.scroll_position,
+                    history_size: viewport_state.history_size,
+                    following_live: viewport_state.following_live,
+                };
+                tx.send(Message::Text(serde_json::to_string(&frame_msg)?))
+                    .await?;
+            } else {
+                tracing::debug!(
+                    session_id = %session_id,
+                    action = ?action,
+                    action_seq,
+                    "tmux viewport frame capture returned no bytes"
+                );
+            }
             let state_msg = ServerMessage::TmuxViewportState {
                 session_id: session_id.clone(),
+                action_seq: Some(action_seq),
                 in_copy_mode: viewport_state.in_copy_mode,
                 scroll_position: viewport_state.scroll_position,
                 history_size: viewport_state.history_size,
@@ -2364,6 +2404,7 @@ async fn process_client_msg(
                     // Clean up view counts for this session
                     st.session_view_counts.remove(&session_id);
                     st.tmux_viewport_controllers.remove(&session_id);
+                    st.tmux_viewport_action_seq.remove(&session_id);
                     clear_mobile_attach_for_session(&mut st, &session_id);
                     for views in st.mobile_views.values_mut() {
                         views.remove(&session_id);
@@ -3801,6 +3842,55 @@ async fn query_tmux_viewport_state(
         .await
         .ok()
         .flatten()
+}
+
+fn capture_tmux_viewport_frame_blocking(
+    socket: &str,
+    session: &str,
+    in_copy_mode: bool,
+) -> Option<Vec<u8>> {
+    let mode_attempts: &[bool] = if in_copy_mode {
+        &[true, false]
+    } else {
+        &[false]
+    };
+    for use_mode_capture in mode_attempts {
+        for target in tmux_targets(session) {
+            let mut cmd = std::process::Command::new("tmux");
+            cmd.arg("-L")
+                .arg(socket)
+                .arg("-f")
+                .arg("/dev/null")
+                .env_remove("TMUX")
+                .arg("capture-pane")
+                .arg("-p")
+                .arg("-e");
+            if *use_mode_capture {
+                cmd.arg("-M");
+            }
+            cmd.arg("-t").arg(&target);
+            let output = cmd.output();
+            if let Ok(out) = output {
+                if out.status.success() {
+                    return Some(out.stdout);
+                }
+            }
+        }
+    }
+    None
+}
+
+async fn capture_tmux_viewport_frame(
+    socket: String,
+    session: String,
+    in_copy_mode: bool,
+) -> Option<Vec<u8>> {
+    tokio::task::spawn_blocking(move || {
+        capture_tmux_viewport_frame_blocking(&socket, &session, in_copy_mode)
+    })
+    .await
+    .ok()
+    .flatten()
 }
 
 fn capture_tmux_history_blocking(

--- a/cli/src/protocol.rs
+++ b/cli/src/protocol.rs
@@ -336,6 +336,18 @@ pub enum ServerMessage {
     /// tmux viewport state after a viewport-control action.
     TmuxViewportState {
         session_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        action_seq: Option<u64>,
+        in_copy_mode: bool,
+        scroll_position: usize,
+        history_size: usize,
+        following_live: bool,
+    },
+    /// tmux viewport frame captured after a viewport-control action.
+    TmuxViewportFrame {
+        session_id: String,
+        action_seq: u64,
+        data: String, // base64 encoded bytes
         in_copy_mode: bool,
         scroll_position: usize,
         history_size: usize,

--- a/docs/TMUX_SHARED_VIEWPORT_V1_PLAN.md
+++ b/docs/TMUX_SHARED_VIEWPORT_V1_PLAN.md
@@ -1,0 +1,61 @@
+# TMUX Shared Viewport V1 Plan
+
+## Goal
+Deliver deterministic tmux scrolling for mobile by making desktop authoritative for viewport content.
+
+## Constraints
+- Keep existing user terminal workflow (Konsole/Terminal/iTerm/PowerShell + tmux session).
+- No client-side synthetic scrollback reconstruction.
+- Preserve live interactive terminal behavior at bottom.
+
+## Architecture
+1. Mobile sends `tmux_viewport` action (`page_up`, `page_down`, `scroll_up`, `scroll_down`, `follow`).
+2. Daemon executes tmux action with retry.
+3. Daemon queries tmux viewport state (`copy_mode`, `scroll_position`, `history_size`).
+4. Daemon captures visible pane frame from tmux (`capture-pane -p -e`, `-M` when in copy-mode).
+5. Daemon sends `tmux_viewport_frame` (base64 bytes, action sequence, state fields).
+6. Daemon sends `tmux_viewport_state` (same action sequence).
+7. Mobile resets xterm canvas and writes frame bytes; no optimistic local paging.
+
+## Protocol Additions
+- `server.tmux_viewport_frame`
+  - `session_id`
+  - `action_seq`
+  - `data` (base64)
+  - `in_copy_mode`
+  - `scroll_position`
+  - `history_size`
+  - `following_live`
+- `server.tmux_viewport_state`
+  - add optional `action_seq` for deterministic state sync.
+
+## Mobile Behavior
+- Block PTY live writes while:
+  - tmux is not following live, or
+  - a viewport action is in-flight.
+- Apply only increasing `action_seq` frames.
+- `follow` restores live mode; deferred keyboard input flushes after follow state confirmation.
+
+## Keyboard/Toolbar Behavior
+- iOS inset source of truth: prefer `screenY` derived inset.
+- Android inset source of truth: prefer `height`.
+- Clamp keyboard lift to avoid extreme jumps.
+- Remove double safe-area accounting while keyboard is visible.
+
+## Risk Controls
+- Action sequencing prevents stale frame overwrites.
+- Action retry remains in daemon.
+- If frame capture fails, state still returns and client remains functional.
+
+## Manual Acceptance Matrix
+1. Swipe up in tmux session: mobile viewport changes each action, no stale frame.
+2. Swipe down/follow: live output resumes and input echoes normally.
+3. Rapid swipes: no crash, no out-of-order viewport render.
+4. Heavy output while scrolled up: mobile remains on frozen viewport until follow.
+5. iOS keyboard open/close: toolbar remains directly above keyboard with no large gap.
+6. Gemini/Codex prompt editing with keyboard visible: input line remains visible.
+
+## Out of Scope (V1)
+- Per-character smooth inertial scroll.
+- Multi-controller arbitration beyond existing controller reassignment.
+- Windows-native tmux edge-case hardening outside WSL path.


### PR DESCRIPTION
## Summary
- add server message `tmux_viewport_frame` with action sequencing
- add optional `action_seq` to `tmux_viewport_state`
- execute tmux viewport actions, capture visible frame, then send frame + state
- track and clean per-session tmux viewport action sequence state
- include `docs/TMUX_SHARED_VIEWPORT_V1_PLAN.md` with architecture and test matrix

## Validation
- `cargo fmt --check`
- `cargo check`
- `cargo test -- --skip filesystem::tests::test_list_directory_sorts_directories_first`