### PR TITLE
fix: run install.sh when piped via curl | bash (#36)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -200,6 +200,6 @@ install() {
 
 # Run installation when executed directly. Tests can source this file to exercise
 # checksum helpers without downloading or installing.
-if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+if [[ "${BASH_SOURCE[0]:-$0}" == "$0" ]]; then
     install
 fi


### PR DESCRIPTION
## Summary

Fixes #36. The documented install path `curl -fsSL .../install.sh | bash` failed with:

```
bash: line 203: BASH_SOURCE[0]: unbound variable
```

and installed nothing.

## Root cause

The entrypoint guard referenced `${BASH_SOURCE[0]}` directly while the script runs under `set -euo pipefail`. When piped, bash reads from stdin and the `BASH_SOURCE` array is empty, so `${BASH_SOURCE[0]}` is an unbound-variable fatal error under `set -u` — aborting before `install()` runs.

## Fix

```diff
-if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+if [[ "${BASH_SOURCE[0]:-$0}" == "$0" ]]; then
```

Defaulting `BASH_SOURCE[0]` to `$0` makes the guard correct in all three modes:

| Mode | `BASH_SOURCE[0]` | `$0` | Result |
|------|------------------|------|--------|
| piped (`curl \| bash`) | empty → defaults to `$0` | `bash` | ✅ install runs |
| file (`bash install.sh`) | `install.sh` | `install.sh` | ✅ install runs |
| sourced (tests) | `install.sh` | parent shell | ✅ install skipped |

> ⚠️ Note: the issue's suggested fix `"${BASH_SOURCE[0]:-}" == "${0:-}"` only **silences the crash** — when piped, `$0` is `"bash"` while `BASH_SOURCE[0]` is empty, so the comparison is false and `install` *still never runs* (exit 0, nothing installed). Defaulting to `$0` is required to actually run the installer.

## Verification

- `bash -n install.sh` — syntax OK
- Piped (`cat install.sh | bash`) now enters `install()` and prints the banner (previously aborted at line 203)
- `scripts/test-installer-checksum.sh` (which sources the script) still passes — `install` does not auto-run when sourced